### PR TITLE
Refactor backend: type safety, security, and N+1 performance

### DIFF
--- a/apps/web/modules/editor/components/header-preview.tsx
+++ b/apps/web/modules/editor/components/header-preview.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { ModeToggle } from "@/components/mode-toggle";
+import { SiteLogo } from "@/components/site-logo";
+import { cn } from "@/lib/utils";
+import { useCustomizationStyles } from "@/modules/elements/panels/customization/use-site-customization";
+import { SearchBox } from "@/modules/elements/sections/search/search-box";
+import type { Id } from "@baseblocks/backend";
+import type { SiteCustomization } from "@baseblocks/types/elements/customization";
+import { Button } from "@baseblocks/ui/button";
+import { PanelTop } from "lucide-react";
+
+interface HeaderPreviewProps {
+  site: {
+    _id: Id<"sites">;
+    name: string;
+    logoUrl?: string;
+    settings: {
+      showLogo?: boolean;
+      showSiteName?: boolean;
+      showHeaderSearch?: boolean;
+      customization?: SiteCustomization;
+    };
+  };
+  team: {
+    name: string;
+    logoUrl?: string;
+    settings: { primaryColor?: string };
+  };
+  onExit: () => void;
+}
+
+export function HeaderPreview({ site, team, onExit }: HeaderPreviewProps) {
+  const showLogo = site.settings.showLogo !== false;
+  const showSiteName = site.settings.showSiteName !== false;
+  const showHeaderSearch = site.settings.showHeaderSearch === true;
+  const headerColor = site.settings.customization?.headerColor;
+  const customizationStyles = useCustomizationStyles(
+    site.settings.customization,
+  );
+
+  return (
+    <header
+      className={cn(
+        "border-b h-14 shrink-0 flex items-center px-4 z-40",
+        !headerColor &&
+          "bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60",
+      )}
+      style={
+        headerColor
+          ? {
+              ...customizationStyles,
+              backgroundColor: "var(--site-header-bg)",
+              color: "var(--site-header-fg)",
+            }
+          : customizationStyles
+      }
+      {...(headerColor ? { "data-site-customized": "" } : {})}
+    >
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={onExit}
+        className={cn(
+          "mr-3 gap-1.5",
+          headerColor && "text-current hover:bg-current/10",
+        )}
+      >
+        <PanelTop className="h-4 w-4" />
+        Exit Preview
+      </Button>
+
+      <div
+        className={cn(
+          "h-5 w-px mr-3",
+          headerColor ? "bg-current/20" : "bg-border",
+        )}
+      />
+
+      <div className="flex items-center gap-2">
+        {showLogo && <SiteLogo site={site} team={team} />}
+        {showSiteName && <span className="font-semibold">{site.name}</span>}
+      </div>
+
+      <div className="flex items-center gap-3 ml-auto">
+        {showHeaderSearch && (
+          <SearchBox
+            siteId={site._id}
+            usePublicQuery={false}
+            placeholder="Search..."
+            maxResults={5}
+            className="w-64"
+            headerMode={!!headerColor}
+          />
+        )}
+        <ModeToggle
+          className={
+            headerColor ? "text-current hover:bg-current/10" : undefined
+          }
+        />
+      </div>
+    </header>
+  );
+}

--- a/apps/web/modules/editor/editor-header.tsx
+++ b/apps/web/modules/editor/editor-header.tsx
@@ -1,11 +1,6 @@
 "use client";
 
-import { ModeToggle } from "@/components/mode-toggle";
-import { SiteLogo } from "@/components/site-logo";
 import { getSiteUrl } from "@/lib/url";
-import { cn } from "@/lib/utils";
-import { useCustomizationStyles } from "@/modules/elements/panels/customization/use-site-customization";
-import { SearchBox } from "@/modules/elements/sections/search/search-box";
 import { useEditorContext } from "@/modules/shared/contexts/editor-context";
 import type {
   AccessCodeData,
@@ -53,6 +48,7 @@ import { useState } from "react";
 import { toast } from "sonner";
 import { DeployDialog } from "./components/deploy-dialog";
 import { DeploymentHistoryPanel } from "./components/deployment-history-panel";
+import { HeaderPreview } from "./components/header-preview";
 import { ShareDialog } from "./components/share-dialog";
 
 interface EditorHeaderProps {
@@ -79,6 +75,16 @@ interface EditorHeaderProps {
     logoUrl?: string;
     settings: { primaryColor?: string };
   };
+}
+
+function getPreviewUrl(teamSlug: string, siteSlug: string) {
+  const isLocalhost =
+    window.location.hostname === "localhost" ||
+    window.location.hostname === "127.0.0.1" ||
+    window.location.hostname.endsWith(".localhost");
+  return isLocalhost
+    ? `http://${teamSlug}.localhost:${window.location.port || "3000"}/${siteSlug}`
+    : getSiteUrl(teamSlug, siteSlug);
 }
 
 export function EditorHeader({
@@ -170,81 +176,20 @@ export function EditorHeader({
   );
 
   const showHeader = site.settings.showHeader !== false;
-  const showLogo = site.settings.showLogo !== false;
-  const showSiteName = site.settings.showSiteName !== false;
-  const showHeaderSearch = site.settings.showHeaderSearch === true;
-  const headerColor = site.settings.customization?.headerColor;
-  const customizationStyles = useCustomizationStyles(
-    site.settings.customization,
-  );
+  const liveUrl = getSiteUrl(teamSlug, siteSlug);
 
   // Preview mode: show the site header as users will see it
   if (isHeaderPreview && showHeader) {
     return (
-      <header
-        className={cn(
-          "border-b h-14 shrink-0 flex items-center px-4 z-40",
-          !headerColor &&
-            "bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60",
-        )}
-        style={
-          headerColor
-            ? {
-                ...customizationStyles,
-                backgroundColor: "var(--site-header-bg)",
-                color: "var(--site-header-fg)",
-              }
-            : customizationStyles
-        }
-        {...(headerColor ? { "data-site-customized": "" } : {})}
-      >
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => setIsHeaderPreview(false)}
-          className={cn(
-            "mr-3 gap-1.5",
-            headerColor && "text-current hover:bg-current/10",
-          )}
-        >
-          <PanelTop className="h-4 w-4" />
-          Exit Preview
-        </Button>
-
-        <div
-          className={cn(
-            "h-5 w-px mr-3",
-            headerColor ? "bg-current/20" : "bg-border",
-          )}
-        />
-
-        <div className="flex items-center gap-2">
-          {showLogo && <SiteLogo site={site} team={team} />}
-          {showSiteName && <span className="font-semibold">{site.name}</span>}
-        </div>
-
-        <div className="flex items-center gap-3 ml-auto">
-          {showHeaderSearch && (
-            <SearchBox
-              siteId={site._id}
-              usePublicQuery={false}
-              placeholder="Search..."
-              maxResults={5}
-              className="w-64"
-              headerMode={!!headerColor}
-            />
-          )}
-          <ModeToggle
-            className={
-              headerColor ? "text-current hover:bg-current/10" : undefined
-            }
-          />
-        </div>
-      </header>
+      <HeaderPreview
+        site={site}
+        team={team}
+        onExit={() => setIsHeaderPreview(false)}
+      />
     );
   }
 
-  // Editor mode: normal editor controls
+  // Editor mode
   return (
     <>
       <header className="border-b h-14 shrink-0 flex items-center justify-between px-4 bg-background z-40">
@@ -252,52 +197,14 @@ export function EditorHeader({
         <div className="flex items-center gap-2">
           <SidebarTrigger />
           {canEdit && (
-            <>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon-sm"
-                    disabled={
-                      isUndoRedoExecuting ||
-                      (!canUndo(currentPageId ?? undefined) && !canUndo())
-                    }
-                    onClick={() => {
-                      if (currentPageId && canUndo(currentPageId)) {
-                        undo(currentPageId);
-                      } else {
-                        undo();
-                      }
-                    }}
-                  >
-                    <Undo2 className="h-4 w-4" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>Undo (Cmd+Z)</TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon-sm"
-                    disabled={
-                      isUndoRedoExecuting ||
-                      (!canRedo(currentPageId ?? undefined) && !canRedo())
-                    }
-                    onClick={() => {
-                      if (currentPageId && canRedo(currentPageId)) {
-                        redo(currentPageId);
-                      } else {
-                        redo();
-                      }
-                    }}
-                  >
-                    <Redo2 className="h-4 w-4" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>Redo (Cmd+Shift+Z)</TooltipContent>
-              </Tooltip>
-            </>
+            <UndoRedoControls
+              canUndo={canUndo}
+              canRedo={canRedo}
+              undo={undo}
+              redo={redo}
+              isExecuting={isUndoRedoExecuting}
+              currentPageId={currentPageId}
+            />
           )}
           {!canEdit && (
             <Badge variant="secondary" className="gap-1">
@@ -339,7 +246,7 @@ export function EditorHeader({
 
         {/* Right section */}
         <div className="flex items-center gap-1">
-          {/* Mobile-only: overflow dropdown for secondary actions */}
+          {/* Mobile-only: overflow dropdown */}
           {canEdit && (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
@@ -349,27 +256,14 @@ export function EditorHeader({
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
                 <DropdownMenuItem
-                  onClick={() => {
-                    const isLocalhost =
-                      window.location.hostname === "localhost" ||
-                      window.location.hostname === "127.0.0.1" ||
-                      window.location.hostname.endsWith(".localhost");
-                    const url = isLocalhost
-                      ? `http://${teamSlug}.localhost:${window.location.port || "3000"}/${siteSlug}`
-                      : getSiteUrl(teamSlug, siteSlug);
-                    window.open(url, "_blank");
-                  }}
+                  onClick={() => window.open(getPreviewUrl(teamSlug, siteSlug), "_blank")}
                 >
                   <Eye />
                   Preview
                 </DropdownMenuItem>
                 {sitePublished && (
                   <DropdownMenuItem asChild>
-                    <a
-                      href={getSiteUrl(teamSlug, siteSlug)}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
+                    <a href={liveUrl} target="_blank" rel="noopener noreferrer">
                       <ExternalLink />
                       {t("editor.viewLive")}
                     </a>
@@ -399,16 +293,7 @@ export function EditorHeader({
                     variant="ghost"
                     size="sm"
                     className="gap-1.5"
-                    onClick={() => {
-                      const isLocalhost =
-                        window.location.hostname === "localhost" ||
-                        window.location.hostname === "127.0.0.1" ||
-                        window.location.hostname.endsWith(".localhost");
-                      const url = isLocalhost
-                        ? `http://${teamSlug}.localhost:${window.location.port || "3000"}/${siteSlug}`
-                        : getSiteUrl(teamSlug, siteSlug);
-                      window.open(url, "_blank");
-                    }}
+                    onClick={() => window.open(getPreviewUrl(teamSlug, siteSlug), "_blank")}
                   >
                     <Eye className="h-4 w-4" />
                     Preview
@@ -425,11 +310,7 @@ export function EditorHeader({
                       className="gap-1.5"
                       asChild
                     >
-                      <a
-                        href={getSiteUrl(teamSlug, siteSlug)}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
+                      <a href={liveUrl} target="_blank" rel="noopener noreferrer">
                         <ExternalLink className="h-4 w-4" />
                         {t("editor.viewLive")}
                       </a>
@@ -474,55 +355,23 @@ export function EditorHeader({
           <Separator orientation="vertical" className="mx-1.5 h-5" />
 
           {/* Primary CTA */}
-          {canEdit &&
-            (hasUndeployedChanges ? (
-              <Button
-                size="sm"
-                onClick={() => setDeployDialogOpen(true)}
-                className="gap-1.5 bg-amber-600 hover:bg-amber-700"
-              >
-                <Rocket className="h-4 w-4" />
-                <span className="hidden md:inline">Deploy Changes</span>
-                <span className="md:hidden">Deploy</span>
-              </Button>
-            ) : sitePublished ? (
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button variant="outline" size="sm" className="gap-1.5">
-                    <Check className="h-3.5 w-3.5 text-emerald-500" />
-                    Published
-                    <ChevronDown className="h-3 w-3 opacity-50" />
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
-                  {onUnpublish && (
-                    <DropdownMenuItem
-                      onClick={onUnpublish}
-                      variant="destructive"
-                    >
-                      <EyeOff />
-                      {t("editor.unpublish")}
-                    </DropdownMenuItem>
-                  )}
-                </DropdownMenuContent>
-              </DropdownMenu>
-            ) : (
-              <Button size="sm" onClick={onPublish}>
-                <Globe className="h-4 w-4" />
-                {t("editor.publish")}
-              </Button>
-            ))}
+          {canEdit && (
+            <DeployCta
+              hasUndeployedChanges={hasUndeployedChanges}
+              sitePublished={sitePublished}
+              onDeploy={() => setDeployDialogOpen(true)}
+              onPublish={onPublish}
+              onUnpublish={onUnpublish}
+              t={t}
+            />
+          )}
 
           {/* View-only: just show View Live if published */}
           {!canEdit && sitePublished && (
             <>
               <Separator orientation="vertical" className="mx-1.5 h-5" />
               <Button variant="outline" size="sm" asChild>
-                <a
-                  href={getSiteUrl(teamSlug, siteSlug)}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
+                <a href={liveUrl} target="_blank" rel="noopener noreferrer">
                   <Globe className="h-4 w-4" />
                   {t("editor.viewLive")}
                 </a>
@@ -532,26 +381,23 @@ export function EditorHeader({
         </div>
       </header>
 
-      {/* Share Dialog */}
       <ShareDialog
         open={shareDialogOpen}
         onOpenChange={setShareDialogOpen}
         siteId={siteId}
         teamSlug={teamSlug}
         siteSlug={siteSlug}
-        siteUrl={getSiteUrl(teamSlug, siteSlug)}
+        siteUrl={liveUrl}
         settings={settings}
         accessCode={accessCode}
       />
 
-      {/* Deploy Dialog */}
       <DeployDialog
         open={deployDialogOpen}
         onOpenChange={setDeployDialogOpen}
         onDeploy={deploySite}
       />
 
-      {/* Deployment History Panel */}
       <DeploymentHistoryPanel
         open={historyOpen}
         onOpenChange={setHistoryOpen}
@@ -560,5 +406,133 @@ export function EditorHeader({
         onRollback={handleRollback}
       />
     </>
+  );
+}
+
+// --------------------------------------------------------------------------
+// Sub-components (co-located, not worth separate files)
+// --------------------------------------------------------------------------
+
+function UndoRedoControls({
+  canUndo,
+  canRedo,
+  undo,
+  redo,
+  isExecuting,
+  currentPageId,
+}: {
+  canUndo: (scope?: string) => boolean;
+  canRedo: (scope?: string) => boolean;
+  undo: (scope?: string) => void;
+  redo: (scope?: string) => void;
+  isExecuting: boolean;
+  currentPageId: string | null;
+}) {
+  return (
+    <>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            disabled={
+              isExecuting ||
+              (!canUndo(currentPageId ?? undefined) && !canUndo())
+            }
+            onClick={() => {
+              if (currentPageId && canUndo(currentPageId)) {
+                undo(currentPageId);
+              } else {
+                undo();
+              }
+            }}
+          >
+            <Undo2 className="h-4 w-4" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>Undo (Cmd+Z)</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            disabled={
+              isExecuting ||
+              (!canRedo(currentPageId ?? undefined) && !canRedo())
+            }
+            onClick={() => {
+              if (currentPageId && canRedo(currentPageId)) {
+                redo(currentPageId);
+              } else {
+                redo();
+              }
+            }}
+          >
+            <Redo2 className="h-4 w-4" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>Redo (Cmd+Shift+Z)</TooltipContent>
+      </Tooltip>
+    </>
+  );
+}
+
+function DeployCta({
+  hasUndeployedChanges,
+  sitePublished,
+  onDeploy,
+  onPublish,
+  onUnpublish,
+  t,
+}: {
+  hasUndeployedChanges: boolean;
+  sitePublished: boolean;
+  onDeploy: () => void;
+  onPublish: () => void;
+  onUnpublish?: () => void;
+  t: ReturnType<typeof useTranslations>;
+}) {
+  if (hasUndeployedChanges) {
+    return (
+      <Button
+        size="sm"
+        onClick={onDeploy}
+        className="gap-1.5 bg-amber-600 hover:bg-amber-700"
+      >
+        <Rocket className="h-4 w-4" />
+        <span className="hidden md:inline">Deploy Changes</span>
+        <span className="md:hidden">Deploy</span>
+      </Button>
+    );
+  }
+
+  if (sitePublished) {
+    return (
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="outline" size="sm" className="gap-1.5">
+            <Check className="h-3.5 w-3.5 text-emerald-500" />
+            Published
+            <ChevronDown className="h-3 w-3 opacity-50" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          {onUnpublish && (
+            <DropdownMenuItem onClick={onUnpublish} variant="destructive">
+              <EyeOff />
+              {t("editor.unpublish")}
+            </DropdownMenuItem>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    );
+  }
+
+  return (
+    <Button size="sm" onClick={onPublish}>
+      <Globe className="h-4 w-4" />
+      {t("editor.publish")}
+    </Button>
   );
 }

--- a/packages/backend/convex/banners/queries.ts
+++ b/packages/backend/convex/banners/queries.ts
@@ -32,35 +32,37 @@ interface BannerBlock {
 export const getSiteWideBanners = query({
   args: { siteId: v.id("sites") },
   handler: async (ctx, { siteId }) => {
-    const pages = await ctx.db
-      .query("pages")
+    // Single query via by_site index (eliminates N+1)
+    const layouts = await ctx.db
+      .query("layouts")
       .withIndex("by_site", (q) => q.eq("siteId", siteId))
       .collect();
 
+    // Build pageId → page lookup for source metadata
+    const pageIds = new Set(layouts.map((l) => l.pageId));
+    const pageMap = new Map<string, { title: string }>();
+    for (const pid of pageIds) {
+      const page = await ctx.db.get(pid);
+      if (page) pageMap.set(pid, { title: page.title });
+    }
+
     const banners: BannerBlock[] = [];
 
-    for (const page of pages) {
-      const layouts = await ctx.db
-        .query("layouts")
-        .withIndex("by_page", (q) => q.eq("pageId", page._id))
-        .collect();
-
-      for (const layout of layouts) {
-        const slots = layout.publishedSlots ?? [];
-        for (const slot of slots) {
-          for (const block of slot.blocks) {
-            if (
-              block.type === "banner" &&
-              block.content?.settings?.scope === "site-wide" &&
-              block.content?.alerts?.length > 0
-            ) {
-              banners.push({
-                id: block.id,
-                content: block.content,
-                sourcePageId: page._id,
-                sourcePageTitle: page.title,
-              });
-            }
+    for (const layout of layouts) {
+      const slots = layout.publishedSlots ?? [];
+      for (const slot of slots) {
+        for (const block of slot.blocks) {
+          if (
+            block.type === "banner" &&
+            block.content?.settings?.scope === "site-wide" &&
+            block.content?.alerts?.length > 0
+          ) {
+            banners.push({
+              id: block.id,
+              content: block.content,
+              sourcePageId: layout.pageId,
+              sourcePageTitle: pageMap.get(layout.pageId)?.title ?? "",
+            });
           }
         }
       }
@@ -74,36 +76,38 @@ export const getSiteWideBanners = query({
 export const getBannersForPage = query({
   args: { siteId: v.id("sites"), pageId: v.id("pages") },
   handler: async (ctx, { siteId, pageId }) => {
-    const pages = await ctx.db
-      .query("pages")
+    // Single query via by_site index (eliminates N+1)
+    const layouts = await ctx.db
+      .query("layouts")
       .withIndex("by_site", (q) => q.eq("siteId", siteId))
       .collect();
 
+    // Build pageId → page lookup for source metadata
+    const pageIds = new Set(layouts.map((l) => l.pageId));
+    const pageMap = new Map<string, { title: string }>();
+    for (const pid of pageIds) {
+      const page = await ctx.db.get(pid);
+      if (page) pageMap.set(pid, { title: page.title });
+    }
+
     const banners: BannerBlock[] = [];
 
-    for (const page of pages) {
-      const layouts = await ctx.db
-        .query("layouts")
-        .withIndex("by_page", (q) => q.eq("pageId", page._id))
-        .collect();
-
-      for (const layout of layouts) {
-        const slots = layout.publishedSlots ?? [];
-        for (const slot of slots) {
-          for (const block of slot.blocks) {
-            if (
-              block.type === "banner" &&
-              block.content?.settings?.scope === "specific-pages" &&
-              block.content?.settings?.targetPageIds?.includes(pageId) &&
-              block.content?.alerts?.length > 0
-            ) {
-              banners.push({
-                id: block.id,
-                content: block.content,
-                sourcePageId: page._id,
-                sourcePageTitle: page.title,
-              });
-            }
+    for (const layout of layouts) {
+      const slots = layout.publishedSlots ?? [];
+      for (const slot of slots) {
+        for (const block of slot.blocks) {
+          if (
+            block.type === "banner" &&
+            block.content?.settings?.scope === "specific-pages" &&
+            block.content?.settings?.targetPageIds?.includes(pageId) &&
+            block.content?.alerts?.length > 0
+          ) {
+            banners.push({
+              id: block.id,
+              content: block.content,
+              sourcePageId: layout.pageId,
+              sourcePageTitle: pageMap.get(layout.pageId)?.title ?? "",
+            });
           }
         }
       }

--- a/packages/backend/convex/deployments/mutations.ts
+++ b/packages/backend/convex/deployments/mutations.ts
@@ -1,7 +1,8 @@
 import { v } from "convex/values";
-import type { Id } from "../_generated/dataModel";
+import type { Doc, Id } from "../_generated/dataModel";
 import { mutation } from "../_generated/server";
 import { requireAdmin } from "../auth";
+import { getLayoutsBySite } from "../lib/resolvers";
 
 /**
  * Deploy site - copies ALL draft fields to published fields for sites, pages, and layouts.
@@ -99,6 +100,9 @@ export const deploy = mutation({
       deploymentVersion: newVersion,
     });
 
+    // Fetch all layouts for site in one query (eliminates N+1)
+    const layoutsByPage = await getLayoutsBySite(ctx, siteId);
+
     // Copy draft → published for each page and its layouts
     for (const page of pages) {
       await ctx.db.patch(page._id, {
@@ -111,10 +115,7 @@ export const deploy = mutation({
         isDeployed: true,
       });
 
-      const layouts = await ctx.db
-        .query("layouts")
-        .withIndex("by_page", (q) => q.eq("pageId", page._id))
-        .collect();
+      const layouts = layoutsByPage.get(page._id) ?? [];
 
       // Snapshot layouts for this page
       const layoutData = layouts.map((l) => ({
@@ -249,7 +250,7 @@ export const rollback = mutation({
       name: string;
       logoUrl?: string;
       defaultPageId?: Id<"pages">;
-      settings: any;
+      settings: Doc<"sites">["settings"];
     };
 
     await ctx.db.patch(siteId, {
@@ -300,34 +301,32 @@ export const rollback = mutation({
     }
 
     // Restore layout published fields from snapshots
-    // First, mark all layouts as not deployed
-    for (const page of allPages) {
-      const layouts = await ctx.db
-        .query("layouts")
-        .withIndex("by_page", (q) => q.eq("pageId", page._id))
-        .collect();
+    // First, mark all layouts as not deployed (single query via by_site index)
+    const allLayouts = await ctx.db
+      .query("layouts")
+      .withIndex("by_site", (q) => q.eq("siteId", siteId))
+      .collect();
 
-      for (const layout of layouts) {
-        await ctx.db.patch(layout._id, {
-          isDeployed: false,
-          publishedSlots: undefined,
-          publishedType: undefined,
-          publishedOrder: undefined,
-          publishedSettings: undefined,
-          publishedTabId: undefined,
-        });
-      }
+    for (const layout of allLayouts) {
+      await ctx.db.patch(layout._id, {
+        isDeployed: false,
+        publishedSlots: undefined,
+        publishedType: undefined,
+        publishedOrder: undefined,
+        publishedSettings: undefined,
+        publishedTabId: undefined,
+      });
     }
 
     // Restore from page-layouts snapshots
     for (const layoutSnapshot of pageLayoutSnapshots) {
       const layoutsData = JSON.parse(layoutSnapshot.data as string) as Array<{
         _id: Id<"layouts">;
-        type: string;
+        type: Doc<"layouts">["type"];
         order: number;
         tabId?: string;
-        slots: any;
-        settings: any;
+        slots: Doc<"layouts">["slots"];
+        settings: Doc<"layouts">["settings"];
       }>;
 
       for (const layoutData of layoutsData) {
@@ -335,7 +334,7 @@ export const rollback = mutation({
         if (layout) {
           await ctx.db.patch(layoutData._id, {
             publishedSlots: layoutData.slots,
-            publishedType: layoutData.type as any,
+            publishedType: layoutData.type,
             publishedOrder: layoutData.order,
             publishedSettings: layoutData.settings,
             publishedTabId: layoutData.tabId,

--- a/packages/backend/convex/documentFolders/mutations.ts
+++ b/packages/backend/convex/documentFolders/mutations.ts
@@ -1,5 +1,6 @@
+import type { GenericMutationCtx } from "convex/server";
 import { v } from "convex/values";
-import type { Doc, Id } from "../_generated/dataModel";
+import type { DataModel, Doc, Id } from "../_generated/dataModel";
 import { mutation } from "../_generated/server";
 import { requireAdmin } from "../auth";
 
@@ -174,14 +175,14 @@ export const move = mutation({
 
 // Helper to recursively delete folder and contents
 async function deleteFolderRecursively(
-  ctx: { db: any },
-  folderId: string,
-  libraryId: string,
+  ctx: Pick<GenericMutationCtx<DataModel>, "db">,
+  folderId: Id<"documentFolders">,
+  libraryId: Id<"documentLibraries">,
 ) {
   // Delete all documents in this folder
   const documents = await ctx.db
     .query("documents")
-    .withIndex("by_folder", (q: any) =>
+    .withIndex("by_folder", (q) =>
       q.eq("libraryId", libraryId).eq("folderId", folderId),
     )
     .collect();
@@ -193,7 +194,7 @@ async function deleteFolderRecursively(
   // Recursively delete child folders
   const children = await ctx.db
     .query("documentFolders")
-    .withIndex("by_parent", (q: any) =>
+    .withIndex("by_parent", (q) =>
       q.eq("libraryId", libraryId).eq("parentId", folderId),
     )
     .collect();

--- a/packages/backend/convex/documents/mutations.ts
+++ b/packages/backend/convex/documents/mutations.ts
@@ -3,16 +3,7 @@ import { mutation } from "../_generated/server";
 import { requireAdmin } from "../auth";
 import { isExtractable } from "../lib/extractable";
 import { markSiteModified } from "../lib/markModified";
-
-// Helper to get teamId from siteId
-async function getTeamIdFromSite(
-  ctx: { db: any },
-  siteId: string,
-): Promise<string | null> {
-  const site = await ctx.db.get(siteId);
-  if (!site) return null;
-  return site.teamId;
-}
+import { resolveSiteContext } from "../lib/resolvers";
 
 // Create document record (after upload to Entity Storage)
 export const create = mutation({
@@ -28,11 +19,10 @@ export const create = mutation({
     ctx,
     { siteId, blobId, cdnUrl, filename, contentType, size },
   ) => {
-    const teamId = await getTeamIdFromSite(ctx, siteId);
-    if (!teamId) throw new Error("Site not found");
+    const siteCtx = await resolveSiteContext(ctx, siteId);
+    if (!siteCtx) throw new Error("Site not found");
 
-    // Require admin access for write operations
-    const { auth } = await requireAdmin(ctx, teamId as any);
+    const { auth } = await requireAdmin(ctx, siteCtx.teamId);
 
     const extractable = isExtractable(contentType);
     const documentId = await ctx.db.insert("documents", {
@@ -93,11 +83,10 @@ export const createInLibrary = mutation({
       size,
     },
   ) => {
-    const teamId = await getTeamIdFromSite(ctx, siteId);
-    if (!teamId) throw new Error("Site not found");
+    const siteCtx = await resolveSiteContext(ctx, siteId);
+    if (!siteCtx) throw new Error("Site not found");
 
-    // Require admin access for write operations
-    const { auth } = await requireAdmin(ctx, teamId as any);
+    const { auth } = await requireAdmin(ctx, siteCtx.teamId);
 
     // Verify library exists and belongs to site
     const library = await ctx.db.get(libraryId);
@@ -160,18 +149,15 @@ export const move = mutation({
     const document = await ctx.db.get(documentId);
     if (!document) throw new Error("Document not found");
 
-    const teamId = await getTeamIdFromSite(ctx, document.siteId);
-    if (!teamId) throw new Error("Site not found");
+    const siteCtx = await resolveSiteContext(ctx, document.siteId);
+    if (!siteCtx) throw new Error("Site not found");
 
-    // Require admin access for write operations
-    await requireAdmin(ctx, teamId as any);
+    await requireAdmin(ctx, siteCtx.teamId);
 
-    // Verify document is in a library
     if (!document.libraryId) {
       throw new Error("Document is not in a library");
     }
 
-    // Verify folder belongs to same library if specified
     if (folderId) {
       const folder = await ctx.db.get(folderId);
       if (!folder || folder.libraryId !== document.libraryId) {
@@ -194,11 +180,10 @@ export const rename = mutation({
     const document = await ctx.db.get(documentId);
     if (!document) throw new Error("Document not found");
 
-    const teamId = await getTeamIdFromSite(ctx, document.siteId);
-    if (!teamId) throw new Error("Site not found");
+    const siteCtx = await resolveSiteContext(ctx, document.siteId);
+    if (!siteCtx) throw new Error("Site not found");
 
-    // Require admin access for write operations
-    await requireAdmin(ctx, teamId as any);
+    await requireAdmin(ctx, siteCtx.teamId);
 
     await ctx.db.patch(documentId, { filename });
     return documentId;
@@ -216,11 +201,10 @@ export const updateMetadata = mutation({
     const document = await ctx.db.get(documentId);
     if (!document) throw new Error("Document not found");
 
-    const teamId = await getTeamIdFromSite(ctx, document.siteId);
-    if (!teamId) throw new Error("Site not found");
+    const siteCtx = await resolveSiteContext(ctx, document.siteId);
+    if (!siteCtx) throw new Error("Site not found");
 
-    // Require admin access for write operations
-    await requireAdmin(ctx, teamId as any);
+    await requireAdmin(ctx, siteCtx.teamId);
 
     const updates: Record<string, unknown> = {};
     if (extractedText !== undefined) updates.extractedText = extractedText;
@@ -238,16 +222,15 @@ export const remove = mutation({
     const document = await ctx.db.get(documentId);
     if (!document) throw new Error("Document not found");
 
-    const teamId = await getTeamIdFromSite(ctx, document.siteId);
-    if (!teamId) throw new Error("Site not found");
+    const siteCtx = await resolveSiteContext(ctx, document.siteId);
+    if (!siteCtx) throw new Error("Site not found");
 
-    // Require admin access for write operations
-    await requireAdmin(ctx, teamId as any);
+    await requireAdmin(ctx, siteCtx.teamId);
 
     // Remove from search index
     const searchEntry = await ctx.db
       .query("searchableContent")
-      .withIndex("by_source", (q: any) =>
+      .withIndex("by_source", (q) =>
         q.eq("contentType", "document").eq("sourceId", documentId),
       )
       .first();

--- a/packages/backend/convex/documents/queries.ts
+++ b/packages/backend/convex/documents/queries.ts
@@ -1,7 +1,9 @@
+import type { GenericQueryCtx } from "convex/server";
 import { v } from "convex/values";
-import type { Doc, Id } from "../_generated/dataModel";
+import type { DataModel, Doc, Id } from "../_generated/dataModel";
 import { query } from "../_generated/server";
 import { requireMember } from "../auth";
+import { getActiveLibraryIds } from "../lib/resolvers";
 
 // ============================================================================
 // Helper Functions
@@ -84,7 +86,7 @@ function formatSearchResult(
  * @param activeLibraryIds - If provided, only return documents from these libraries (for public search filtering)
  */
 async function performSearch(
-  ctx: { db: { query: (table: "documents") => any } },
+  ctx: Pick<GenericQueryCtx<DataModel>, "db">,
   siteId: Id<"sites">,
   searchTerm: string,
   limit: number,
@@ -93,7 +95,7 @@ async function performSearch(
   // 1. Search by content (full-text search)
   const contentResults = await ctx.db
     .query("documents")
-    .withSearchIndex("search_content", (q: any) =>
+    .withSearchIndex("search_content", (q) =>
       q.search("extractedText", searchTerm).eq("siteId", siteId),
     )
     .take(limit * 2); // Fetch more to account for filtering
@@ -101,7 +103,7 @@ async function performSearch(
   // 2. Search by filename (using search index for better performance)
   const filenameResults = await ctx.db
     .query("documents")
-    .withSearchIndex("search_filename", (q: any) =>
+    .withSearchIndex("search_filename", (q) =>
       q.search("filename", searchTerm).eq("siteId", siteId),
     )
     .take(limit * 2);
@@ -210,31 +212,7 @@ export const searchPublic = query({
     const site = await ctx.db.get(siteId);
     if (!site || !site.isPublished) return [];
 
-    // Get active library IDs (libraries that are used in blocks on pages)
-    const pages = await ctx.db
-      .query("pages")
-      .withIndex("by_site", (q) => q.eq("siteId", siteId))
-      .collect();
-
-    const activeLibraryIds = new Set<string>();
-    for (const page of pages) {
-      const layouts = await ctx.db
-        .query("layouts")
-        .withIndex("by_page", (q) => q.eq("pageId", page._id))
-        .collect();
-
-      for (const layout of layouts) {
-        // ONLY use publishedSlots for public content - never fall back to draft
-        const slotsToScan = layout.publishedSlots ?? [];
-        for (const slot of slotsToScan) {
-          for (const block of slot.blocks) {
-            if (block.type === "library" && block.content?.libraryId) {
-              activeLibraryIds.add(block.content.libraryId);
-            }
-          }
-        }
-      }
-    }
+    const activeLibraryIds = await getActiveLibraryIds(ctx, siteId);
 
     // Use shared search logic with active library filter
     return performSearch(
@@ -426,7 +404,7 @@ export const searchByLibrary = query({
     // Search by content
     const contentResults = await ctx.db
       .query("documents")
-      .withSearchIndex("search_content", (q: any) =>
+      .withSearchIndex("search_content", (q) =>
         q.search("extractedText", trimmed).eq("siteId", site._id),
       )
       .take(limit * 2);
@@ -434,7 +412,7 @@ export const searchByLibrary = query({
     // Search by filename
     const filenameResults = await ctx.db
       .query("documents")
-      .withSearchIndex("search_filename", (q: any) =>
+      .withSearchIndex("search_filename", (q) =>
         q.search("filename", trimmed).eq("siteId", site._id),
       )
       .take(limit * 2);

--- a/packages/backend/convex/layouts/mutations.ts
+++ b/packages/backend/convex/layouts/mutations.ts
@@ -1,8 +1,11 @@
 import { v } from "convex/values";
-import type { Id } from "../_generated/dataModel";
 import { mutation } from "../_generated/server";
 import { requireAdmin } from "../auth";
 import { markSiteModified } from "../lib/markModified";
+import {
+  resolveLayoutContext,
+  resolvePageContext,
+} from "../lib/resolvers";
 import {
   blockContent,
   layoutSettings,
@@ -10,37 +13,6 @@ import {
   layoutType,
   slotBlock,
 } from "./validators";
-
-// Helper to get teamId from pageId
-async function getTeamIdFromPage(
-  ctx: { db: any },
-  pageId: string,
-): Promise<{ teamId: string; siteId: string } | null> {
-  const page = await ctx.db.get(pageId);
-  if (!page) return null;
-
-  const site = await ctx.db.get(page.siteId);
-  if (!site) return null;
-
-  return { teamId: site.teamId, siteId: site._id };
-}
-
-// Helper to get teamId from layoutId
-async function getTeamIdFromLayout(
-  ctx: { db: any },
-  layoutId: string,
-): Promise<{ teamId: string; pageId: string; siteId: string } | null> {
-  const layout = await ctx.db.get(layoutId);
-  if (!layout) return null;
-
-  const page = await ctx.db.get(layout.pageId);
-  if (!page) return null;
-
-  const site = await ctx.db.get(page.siteId);
-  if (!site) return null;
-
-  return { teamId: site.teamId, pageId: layout.pageId, siteId: site._id };
-}
 
 // Create a new layout
 export const create = mutation({
@@ -53,27 +25,26 @@ export const create = mutation({
     tabId: v.optional(v.string()),
   },
   handler: async (ctx, { pageId, type, slots, settings, order, tabId }) => {
-    const pageInfo = await getTeamIdFromPage(ctx, pageId);
+    const pageInfo = await resolvePageContext(ctx, pageId);
     if (!pageInfo) throw new Error("Page not found");
 
-    // Require admin access for write operations
-    await requireAdmin(ctx, pageInfo.teamId as any);
+    await requireAdmin(ctx, pageInfo.teamId);
 
     // Get max order if not specified (scoped to same tab)
     let layoutOrder = order;
     if (layoutOrder === undefined) {
       const existingLayouts = await ctx.db
         .query("layouts")
-        .withIndex("by_page", (q: any) => q.eq("pageId", pageId))
+        .withIndex("by_page", (q) => q.eq("pageId", pageId))
         .collect();
-      const tabLayouts = existingLayouts.filter((l: any) => l.tabId === tabId);
+      const tabLayouts = existingLayouts.filter((l) => l.tabId === tabId);
       layoutOrder =
-        tabLayouts.reduce((max: number, s: any) => Math.max(max, s.order), -1) +
-        1;
+        tabLayouts.reduce((max, l) => Math.max(max, l.order), -1) + 1;
     }
 
     const now = Date.now();
     const layoutId = await ctx.db.insert("layouts", {
+      siteId: pageInfo.siteId,
       pageId,
       tabId,
       type,
@@ -84,9 +55,8 @@ export const create = mutation({
       updatedAt: now,
     });
 
-    // Update page updatedAt and mark site modified
     await ctx.db.patch(pageId, { updatedAt: now });
-    await markSiteModified(ctx, pageInfo.siteId as Id<"sites">);
+    await markSiteModified(ctx, pageInfo.siteId);
 
     return layoutId;
   },
@@ -102,11 +72,10 @@ export const updateSettings = mutation({
     const layout = await ctx.db.get(layoutId);
     if (!layout) throw new Error("Layout not found");
 
-    const layoutInfo = await getTeamIdFromLayout(ctx, layoutId);
+    const layoutInfo = await resolveLayoutContext(ctx, layoutId);
     if (!layoutInfo) throw new Error("Layout not found");
 
-    // Require admin access for write operations
-    await requireAdmin(ctx, layoutInfo.teamId as any);
+    await requireAdmin(ctx, layoutInfo.teamId);
 
     const now = Date.now();
     await ctx.db.patch(layoutId, {
@@ -114,7 +83,7 @@ export const updateSettings = mutation({
       updatedAt: now,
     });
     await ctx.db.patch(layout.pageId, { updatedAt: now });
-    await markSiteModified(ctx, layoutInfo.siteId as Id<"sites">);
+    await markSiteModified(ctx, layoutInfo.siteId);
 
     return layoutId;
   },
@@ -130,11 +99,10 @@ export const updateSlots = mutation({
     const layout = await ctx.db.get(layoutId);
     if (!layout) throw new Error("Layout not found");
 
-    const layoutInfo = await getTeamIdFromLayout(ctx, layoutId);
+    const layoutInfo = await resolveLayoutContext(ctx, layoutId);
     if (!layoutInfo) throw new Error("Layout not found");
 
-    // Require admin access for write operations
-    await requireAdmin(ctx, layoutInfo.teamId as any);
+    await requireAdmin(ctx, layoutInfo.teamId);
 
     const now = Date.now();
     await ctx.db.patch(layoutId, {
@@ -142,7 +110,7 @@ export const updateSlots = mutation({
       updatedAt: now,
     });
     await ctx.db.patch(layout.pageId, { updatedAt: now });
-    await markSiteModified(ctx, layoutInfo.siteId as Id<"sites">);
+    await markSiteModified(ctx, layoutInfo.siteId);
 
     return layoutId;
   },
@@ -160,14 +128,12 @@ export const addBlockToSlot = mutation({
     const layout = await ctx.db.get(layoutId);
     if (!layout) throw new Error("Layout not found");
 
-    const layoutInfo = await getTeamIdFromLayout(ctx, layoutId);
+    const layoutInfo = await resolveLayoutContext(ctx, layoutId);
     if (!layoutInfo) throw new Error("Layout not found");
 
-    // Require admin access for write operations
-    await requireAdmin(ctx, layoutInfo.teamId as any);
+    await requireAdmin(ctx, layoutInfo.teamId);
 
-    // Find slot and add block
-    const updatedSlots = layout.slots.map((slot: any) => {
+    const updatedSlots = layout.slots.map((slot) => {
       if (slot.id !== slotId) return slot;
 
       const newBlocks = [...slot.blocks];
@@ -185,7 +151,7 @@ export const addBlockToSlot = mutation({
       updatedAt: now,
     });
     await ctx.db.patch(layout.pageId, { updatedAt: now });
-    await markSiteModified(ctx, layoutInfo.siteId as Id<"sites">);
+    await markSiteModified(ctx, layoutInfo.siteId);
 
     return layoutId;
   },
@@ -203,17 +169,15 @@ export const updateBlockInSlot = mutation({
     const layout = await ctx.db.get(layoutId);
     if (!layout) throw new Error("Layout not found");
 
-    const layoutInfo = await getTeamIdFromLayout(ctx, layoutId);
+    const layoutInfo = await resolveLayoutContext(ctx, layoutId);
     if (!layoutInfo) throw new Error("Layout not found");
 
-    // Require admin access for write operations
-    await requireAdmin(ctx, layoutInfo.teamId as any);
+    await requireAdmin(ctx, layoutInfo.teamId);
 
-    // Find slot and update block
-    const updatedSlots = layout.slots.map((slot: any) => {
+    const updatedSlots = layout.slots.map((slot) => {
       if (slot.id !== slotId) return slot;
 
-      const updatedBlocks = slot.blocks.map((b: any) =>
+      const updatedBlocks = slot.blocks.map((b) =>
         b.id === blockId ? { ...b, content } : b,
       );
       return { ...slot, blocks: updatedBlocks };
@@ -225,7 +189,7 @@ export const updateBlockInSlot = mutation({
       updatedAt: now,
     });
     await ctx.db.patch(layout.pageId, { updatedAt: now });
-    await markSiteModified(ctx, layoutInfo.siteId as Id<"sites">);
+    await markSiteModified(ctx, layoutInfo.siteId);
 
     return layoutId;
   },
@@ -242,19 +206,17 @@ export const removeBlockFromSlot = mutation({
     const layout = await ctx.db.get(layoutId);
     if (!layout) throw new Error("Layout not found");
 
-    const layoutInfo = await getTeamIdFromLayout(ctx, layoutId);
+    const layoutInfo = await resolveLayoutContext(ctx, layoutId);
     if (!layoutInfo) throw new Error("Layout not found");
 
-    // Require admin access for write operations
-    await requireAdmin(ctx, layoutInfo.teamId as any);
+    await requireAdmin(ctx, layoutInfo.teamId);
 
-    // Find slot and remove block
-    const updatedSlots = layout.slots.map((slot: any) => {
+    const updatedSlots = layout.slots.map((slot) => {
       if (slot.id !== slotId) return slot;
 
       return {
         ...slot,
-        blocks: slot.blocks.filter((b: any) => b.id !== blockId),
+        blocks: slot.blocks.filter((b) => b.id !== blockId),
       };
     });
 
@@ -264,7 +226,7 @@ export const removeBlockFromSlot = mutation({
       updatedAt: now,
     });
     await ctx.db.patch(layout.pageId, { updatedAt: now });
-    await markSiteModified(ctx, layoutInfo.siteId as Id<"sites">);
+    await markSiteModified(ctx, layoutInfo.siteId);
 
     return layoutId;
   },
@@ -286,13 +248,12 @@ export const moveBlock = mutation({
     const layout = await ctx.db.get(layoutId);
     if (!layout) throw new Error("Layout not found");
 
-    const layoutInfo = await getTeamIdFromLayout(ctx, layoutId);
+    const layoutInfo = await resolveLayoutContext(ctx, layoutId);
     if (!layoutInfo) throw new Error("Layout not found");
 
-    // Require admin access for write operations
-    await requireAdmin(ctx, layoutInfo.teamId as any);
+    await requireAdmin(ctx, layoutInfo.teamId);
 
-    // Find the block - use the same type as in slots
+    // Find the block
     type SlotBlock = (typeof layout.slots)[0]["blocks"][0];
     let blockToMove: SlotBlock | undefined;
     for (const slot of layout.slots) {
@@ -319,20 +280,18 @@ export const moveBlock = mutation({
         updatedAt: now,
       });
       await ctx.db.patch(layout.pageId, { updatedAt: now });
-      await markSiteModified(ctx, layoutInfo.siteId as Id<"sites">);
+      await markSiteModified(ctx, layoutInfo.siteId);
       return layoutId;
     }
 
     // Move between different slots
     const updatedSlots = layout.slots.map((slot) => {
-      // Remove from source
       if (slot.id === fromSlotId) {
         return {
           ...slot,
           blocks: slot.blocks.filter((b) => b.id !== blockId),
         };
       }
-      // Add to destination
       if (slot.id === toSlotId) {
         const newBlocks = [...slot.blocks];
         newBlocks.splice(toIndex, 0, blockToMove!);
@@ -347,7 +306,7 @@ export const moveBlock = mutation({
       updatedAt: now,
     });
     await ctx.db.patch(layout.pageId, { updatedAt: now });
-    await markSiteModified(ctx, layoutInfo.siteId as Id<"sites">);
+    await markSiteModified(ctx, layoutInfo.siteId);
 
     return layoutId;
   },
@@ -360,13 +319,11 @@ export const reorder = mutation({
     layoutIds: v.array(v.id("layouts")),
   },
   handler: async (ctx, { pageId, layoutIds }) => {
-    const pageInfo = await getTeamIdFromPage(ctx, pageId);
+    const pageInfo = await resolvePageContext(ctx, pageId);
     if (!pageInfo) throw new Error("Page not found");
 
-    // Require admin access for write operations
-    await requireAdmin(ctx, pageInfo.teamId as any);
+    await requireAdmin(ctx, pageInfo.teamId);
 
-    // Update order for each layout
     for (let i = 0; i < layoutIds.length; i++) {
       const layoutId = layoutIds[i];
       if (layoutId) {
@@ -375,7 +332,7 @@ export const reorder = mutation({
     }
 
     await ctx.db.patch(pageId, { updatedAt: Date.now() });
-    await markSiteModified(ctx, pageInfo.siteId as Id<"sites">);
+    await markSiteModified(ctx, pageInfo.siteId);
   },
 });
 
@@ -386,15 +343,14 @@ export const remove = mutation({
     const layout = await ctx.db.get(layoutId);
     if (!layout) throw new Error("Layout not found");
 
-    const layoutInfo = await getTeamIdFromLayout(ctx, layoutId);
+    const layoutInfo = await resolveLayoutContext(ctx, layoutId);
     if (!layoutInfo) throw new Error("Layout not found");
 
-    // Require admin access for write operations
-    await requireAdmin(ctx, layoutInfo.teamId as any);
+    await requireAdmin(ctx, layoutInfo.teamId);
 
     await ctx.db.delete(layoutId);
     await ctx.db.patch(layout.pageId, { updatedAt: Date.now() });
-    await markSiteModified(ctx, layoutInfo.siteId as Id<"sites">);
+    await markSiteModified(ctx, layoutInfo.siteId);
   },
 });
 
@@ -412,10 +368,10 @@ export const addSubpageBlock = mutation({
     const layout = await ctx.db.get(layoutId);
     if (!layout) throw new Error("Layout not found");
 
-    const layoutInfo = await getTeamIdFromLayout(ctx, layoutId);
+    const layoutInfo = await resolveLayoutContext(ctx, layoutId);
     if (!layoutInfo) throw new Error("Layout not found");
 
-    const { auth } = await requireAdmin(ctx, layoutInfo.teamId as any);
+    const { auth } = await requireAdmin(ctx, layoutInfo.teamId);
 
     const page = await ctx.db.get(layout.pageId);
     if (!page) throw new Error("Page not found");
@@ -423,7 +379,7 @@ export const addSubpageBlock = mutation({
     // Check slug uniqueness
     const existingSlug = await ctx.db
       .query("pages")
-      .withIndex("by_slug", (q: any) =>
+      .withIndex("by_slug", (q) =>
         q.eq("siteId", page.siteId).eq("slug", slug.toLowerCase()),
       )
       .first();
@@ -438,14 +394,11 @@ export const addSubpageBlock = mutation({
     // 1. Create child page
     const siblings = await ctx.db
       .query("pages")
-      .withIndex("by_parent", (q: any) =>
+      .withIndex("by_parent", (q) =>
         q.eq("siteId", page.siteId).eq("parentId", layout.pageId),
       )
       .collect();
-    const maxOrder = siblings.reduce(
-      (max: number, p: any) => Math.max(max, p.order),
-      -1,
-    );
+    const maxOrder = siblings.reduce((max, p) => Math.max(max, p.order), -1);
 
     const childPageId = await ctx.db.insert("pages", {
       siteId: page.siteId,
@@ -462,6 +415,7 @@ export const addSubpageBlock = mutation({
 
     // 2. Create default layout on child page
     await ctx.db.insert("layouts", {
+      siteId: page.siteId,
       pageId: childPageId,
       type: "single",
       slots: [{ id: "default-slot", position: 0, blocks: [] }],
@@ -478,7 +432,7 @@ export const addSubpageBlock = mutation({
       content: { pageId: childPageId },
     };
 
-    const updatedSlots = layout.slots.map((s: any) => {
+    const updatedSlots = layout.slots.map((s) => {
       if (s.id !== slotId) return s;
       const newBlocks = [...s.blocks];
       if (index !== undefined && index >= 0 && index <= newBlocks.length) {
@@ -491,7 +445,7 @@ export const addSubpageBlock = mutation({
 
     await ctx.db.patch(layoutId, { slots: updatedSlots, updatedAt: now });
     await ctx.db.patch(layout.pageId, { updatedAt: now });
-    await markSiteModified(ctx, layoutInfo.siteId as Id<"sites">);
+    await markSiteModified(ctx, layoutInfo.siteId);
 
     return { childPageId };
   },

--- a/packages/backend/convex/lib/resolvers.ts
+++ b/packages/backend/convex/lib/resolvers.ts
@@ -1,0 +1,135 @@
+import type { GenericMutationCtx, GenericQueryCtx } from "convex/server";
+import type { DataModel, Doc, Id } from "../_generated/dataModel";
+
+/**
+ * Database context type — works for both queries and mutations.
+ * Replaces the unsafe `ctx: { db: any }` pattern used previously.
+ */
+type DbCtx = Pick<
+  GenericQueryCtx<DataModel> | GenericMutationCtx<DataModel>,
+  "db"
+>;
+
+/**
+ * Resolved page info with properly typed IDs.
+ */
+export type PageInfo = {
+  teamId: Id<"teams">;
+  siteId: Id<"sites">;
+};
+
+/**
+ * Resolved layout info with properly typed IDs.
+ */
+export type LayoutInfo = {
+  teamId: Id<"teams">;
+  siteId: Id<"sites">;
+  pageId: Id<"pages">;
+};
+
+/**
+ * Resolve a page's team and site IDs.
+ * Returns null if page or site doesn't exist.
+ */
+export async function resolvePageContext(
+  ctx: DbCtx,
+  pageId: Id<"pages">,
+): Promise<PageInfo | null> {
+  const page = await ctx.db.get(pageId);
+  if (!page) return null;
+
+  const site = await ctx.db.get(page.siteId);
+  if (!site) return null;
+
+  return { teamId: site.teamId, siteId: site._id };
+}
+
+/**
+ * Resolve a layout's team, site, and page IDs.
+ * Returns null if layout, page, or site doesn't exist.
+ */
+export async function resolveLayoutContext(
+  ctx: DbCtx,
+  layoutId: Id<"layouts">,
+): Promise<LayoutInfo | null> {
+  const layout = await ctx.db.get(layoutId);
+  if (!layout) return null;
+
+  const page = await ctx.db.get(layout.pageId);
+  if (!page) return null;
+
+  const site = await ctx.db.get(page.siteId);
+  if (!site) return null;
+
+  return { teamId: site.teamId, siteId: site._id, pageId: layout.pageId };
+}
+
+/**
+ * Resolve a site's team ID.
+ * Returns null if site doesn't exist.
+ */
+export async function resolveSiteContext(
+  ctx: DbCtx,
+  siteId: Id<"sites">,
+): Promise<{ teamId: Id<"teams"> } | null> {
+  const site = await ctx.db.get(siteId);
+  if (!site) return null;
+
+  return { teamId: site.teamId };
+}
+
+/**
+ * Collect library IDs that are actively used in published blocks across a site.
+ * Uses the layouts by_site index for O(1) query instead of N+1 per-page lookups.
+ */
+export async function getActiveLibraryIds(
+  ctx: DbCtx,
+  siteId: Id<"sites">,
+): Promise<Set<string>> {
+  // Single query via denormalized siteId on layouts
+  const layouts = await ctx.db
+    .query("layouts")
+    .withIndex("by_site", (q) => q.eq("siteId", siteId))
+    .collect();
+
+  const activeLibraryIds = new Set<string>();
+  for (const layout of layouts) {
+    // ONLY use publishedSlots for public content - never fall back to draft
+    const slotsToScan = layout.publishedSlots ?? [];
+    for (const slot of slotsToScan) {
+      for (const block of slot.blocks) {
+        if (block.type === "library" && block.content?.libraryId) {
+          activeLibraryIds.add(block.content.libraryId);
+        }
+      }
+    }
+  }
+
+  return activeLibraryIds;
+}
+
+/**
+ * Get all layouts for a site in one query (via denormalized siteId).
+ * Returns a Map of pageId → layouts[] for efficient grouping.
+ */
+export async function getLayoutsBySite(
+  ctx: DbCtx,
+  siteId: Id<"sites">,
+): Promise<Map<string, Doc<"layouts">[]>> {
+  const allLayouts = await ctx.db
+    .query("layouts")
+    .withIndex("by_site", (q) => q.eq("siteId", siteId))
+    .collect();
+
+  const byPage = new Map<string, Doc<"layouts">[]>();
+  for (const layout of allLayouts) {
+    const existing = byPage.get(layout.pageId);
+    if (existing) {
+      existing.push(layout);
+    } else {
+      byPage.set(layout.pageId, [layout]);
+    }
+  }
+
+  return byPage;
+}

--- a/packages/backend/convex/lib/tree.ts
+++ b/packages/backend/convex/lib/tree.ts
@@ -1,0 +1,72 @@
+import type { Doc } from "../_generated/dataModel";
+
+/**
+ * A page node in the tree structure.
+ * Used for both draft and published page trees.
+ */
+export type PageTreeNode = {
+  _id: string;
+  siteId: Doc<"pages">["siteId"];
+  title: string;
+  slug: string;
+  icon?: string;
+  order: number;
+  parentId?: string;
+  pageTabs?: Array<{ id: string; label: string }>;
+  children: PageTreeNode[];
+};
+
+type ProjectedPage = {
+  _id: string;
+  siteId: Doc<"pages">["siteId"];
+  title: string;
+  slug: string;
+  icon?: string;
+  order: number;
+  parentId?: string;
+  pageTabs?: Array<{ id: string; label: string }>;
+};
+
+/**
+ * Build a tree structure from a flat array of pages.
+ * Shared by both getTree (draft) and getTreePublished (published).
+ *
+ * @param pages - Flat array of page data (already projected to the right fields)
+ * @returns Root-level tree nodes with nested children, sorted by order
+ */
+export function buildPageTree(pages: ProjectedPage[]): PageTreeNode[] {
+  const pageMap = new Map<string, PageTreeNode>();
+  const rootPages: PageTreeNode[] = [];
+
+  // First pass: create map with empty children
+  for (const page of pages) {
+    pageMap.set(page._id, { ...page, children: [] });
+  }
+
+  // Second pass: build tree
+  for (const node of pageMap.values()) {
+    if (node.parentId) {
+      const parent = pageMap.get(node.parentId);
+      if (parent) {
+        parent.children.push(node);
+      } else {
+        // Parent not in set (e.g., not deployed), treat as root
+        rootPages.push(node);
+      }
+    } else {
+      rootPages.push(node);
+    }
+  }
+
+  // Sort children by order recursively
+  sortChildren(rootPages);
+
+  return rootPages;
+}
+
+function sortChildren(pages: PageTreeNode[]) {
+  pages.sort((a, b) => a.order - b.order);
+  for (const page of pages) {
+    sortChildren(page.children);
+  }
+}

--- a/packages/backend/convex/migrations.ts
+++ b/packages/backend/convex/migrations.ts
@@ -611,3 +611,25 @@ export const runDataCleanup = migrations.runner([
   internal.migrations.normalizeDecisionTreeContent,
   internal.migrations.stringifySnapshotData,
 ]);
+
+// ============================================================
+// Migration 14: Backfill siteId on layouts
+// ============================================================
+// New denormalized field for efficient site-wide layout queries.
+// Resolves siteId by looking up the layout's page.
+
+export const backfillLayoutSiteId = migrations.define({
+  table: "layouts",
+  batchSize: 50,
+  migrateOne: async (ctx, layout) => {
+    if (layout.siteId) return; // Already set
+
+    const page = await ctx.db.get(layout.pageId);
+    if (!page) return;
+
+    await ctx.db.patch(layout._id, { siteId: page.siteId });
+  },
+});
+export const runBackfillLayoutSiteId = migrations.runner([
+  internal.migrations.backfillLayoutSiteId,
+]);

--- a/packages/backend/convex/pages/mutations.ts
+++ b/packages/backend/convex/pages/mutations.ts
@@ -1,5 +1,7 @@
 import { v } from "convex/values";
 import type { Doc, Id } from "../_generated/dataModel";
+import type { GenericMutationCtx } from "convex/server";
+import type { DataModel } from "../_generated/dataModel";
 import { mutation } from "../_generated/server";
 import { requireAdmin } from "../auth";
 import { markSiteModified } from "../lib/markModified";
@@ -14,11 +16,9 @@ export const create = mutation({
     icon: v.optional(v.string()),
   },
   handler: async (ctx, { siteId, title, slug, parentId, icon }) => {
-    // Verify access to site
     const site = await ctx.db.get(siteId);
     if (!site) throw new Error("Site not found");
 
-    // Require admin access for write operations
     const { auth } = await requireAdmin(ctx, site.teamId);
 
     // Check slug uniqueness
@@ -79,7 +79,6 @@ export const update = mutation({
     const site = await ctx.db.get(page.siteId);
     if (!site) throw new Error("Site not found");
 
-    // Require admin access for write operations
     await requireAdmin(ctx, site.teamId);
 
     // Check slug uniqueness if changing
@@ -122,10 +121,8 @@ export const reorder = mutation({
     const site = await ctx.db.get(siteId);
     if (!site) throw new Error("Site not found");
 
-    // Require admin access for write operations
     await requireAdmin(ctx, site.teamId);
 
-    // Update order for each page based on its position in the array
     const now = Date.now();
     for (let i = 0; i < pageIds.length; i++) {
       const pageId = pageIds[i];
@@ -142,14 +139,14 @@ export const reorder = mutation({
 
 // Helper to recursively delete a page and its children
 async function deletePageRecursively(
-  ctx: { db: any },
-  pageId: string,
-  siteId: string,
+  ctx: Pick<GenericMutationCtx<DataModel>, "db">,
+  pageId: Id<"pages">,
+  siteId: Id<"sites">,
 ) {
   // Delete all layouts for this page
   const layouts = await ctx.db
     .query("layouts")
-    .withIndex("by_page", (q: any) => q.eq("pageId", pageId))
+    .withIndex("by_page", (q) => q.eq("pageId", pageId))
     .collect();
 
   for (const layout of layouts) {
@@ -159,7 +156,7 @@ async function deletePageRecursively(
   // Recursively delete child pages
   const children = await ctx.db
     .query("pages")
-    .withIndex("by_parent", (q: any) =>
+    .withIndex("by_parent", (q) =>
       q.eq("siteId", siteId).eq("parentId", pageId),
     )
     .collect();
@@ -179,14 +176,12 @@ export const move = mutation({
     newOrder: v.number(),
   },
   handler: async (ctx, { pageId, newParentId, newOrder }) => {
-    // Get page and verify exists
     const page = await ctx.db.get(pageId);
     if (!page) throw new Error("Page not found");
 
     const site = await ctx.db.get(page.siteId);
     if (!site) throw new Error("Site not found");
 
-    // Require admin access for write operations
     await requireAdmin(ctx, site.teamId);
 
     // Verify new parent exists if specified
@@ -197,7 +192,6 @@ export const move = mutation({
       }
 
       // Prevent moving page into itself or its descendants
-      // Walk up the parent chain from newParentId to check for circular reference
       let checkId: Id<"pages"> | undefined = newParentId;
       while (checkId) {
         if (checkId === pageId) {
@@ -208,7 +202,6 @@ export const move = mutation({
       }
     }
 
-    // Update the page with new parent and order
     await ctx.db.patch(pageId, {
       parentId: newParentId,
       order: newOrder,
@@ -279,10 +272,9 @@ export const enablePageTabs = mutation({
       return pageId;
     }
 
-    // Get all existing layouts for this page
     const existingLayouts = await ctx.db
       .query("layouts")
-      .withIndex("by_page", (q: any) => q.eq("pageId", pageId))
+      .withIndex("by_page", (q) => q.eq("pageId", pageId))
       .collect();
 
     const now = Date.now();
@@ -295,7 +287,6 @@ export const enablePageTabs = mutation({
       }
     }
 
-    // Set pageTabs on the page
     await ctx.db.patch(pageId, {
       pageTabs: tabs,
       updatedAt: now,
@@ -321,10 +312,9 @@ export const disablePageTabs = mutation({
 
     await requireAdmin(ctx, site.teamId);
 
-    // Clear tabId from all layouts
     const layouts = await ctx.db
       .query("layouts")
-      .withIndex("by_page", (q: any) => q.eq("pageId", pageId))
+      .withIndex("by_page", (q) => q.eq("pageId", pageId))
       .collect();
 
     const now = Date.now();
@@ -332,7 +322,6 @@ export const disablePageTabs = mutation({
       await ctx.db.patch(layout._id, { tabId: undefined, updatedAt: now });
     }
 
-    // Remove pageTabs from page
     await ctx.db.patch(pageId, {
       pageTabs: undefined,
       updatedAt: now,
@@ -354,22 +343,19 @@ export const remove = mutation({
     const site = await ctx.db.get(page.siteId);
     if (!site) throw new Error("Site not found");
 
-    // Require admin access for write operations
     await requireAdmin(ctx, site.teamId);
 
     // Check if this is the default page
     const isDefaultPage = site.defaultPageId === pageId;
 
-    // Get all root-level pages (excluding the one being deleted and its children)
+    // Get all pages for descendant collection
     const allPages = await ctx.db
       .query("pages")
       .withIndex("by_site", (q) => q.eq("siteId", page.siteId))
       .collect();
 
-    // Find pages that will remain after deletion (excluding this page and its descendants)
-    const pagesToDelete = new Set<string>([pageId]);
-
     // Collect all descendant IDs
+    const pagesToDelete = new Set<string>([pageId]);
     const collectDescendants = (parentId: string) => {
       const children = allPages.filter((p) => p.parentId === parentId);
       for (const child of children) {
@@ -385,7 +371,6 @@ export const remove = mutation({
 
     // If deleting the default page, reassign to first remaining page
     if (isDefaultPage) {
-      // Find the first root-level page or fall back to first page
       const firstRootPage = remainingPages.find((p) => !p.parentId);
       const newDefaultPage = firstRootPage ?? remainingPages[0];
 
@@ -395,7 +380,6 @@ export const remove = mutation({
           updatedAt: Date.now(),
         });
       } else {
-        // No pages left, clear the default
         await ctx.db.patch(site._id, {
           defaultPageId: undefined,
           updatedAt: Date.now(),
@@ -403,9 +387,7 @@ export const remove = mutation({
       }
     }
 
-    // Delete the page and all its descendants
     await deletePageRecursively(ctx, pageId, page.siteId);
-
     await markSiteModified(ctx, page.siteId);
 
     return { success: true };

--- a/packages/backend/convex/pages/queries.ts
+++ b/packages/backend/convex/pages/queries.ts
@@ -1,7 +1,8 @@
 import { v } from "convex/values";
 import type { Id } from "../_generated/dataModel";
 import { query } from "../_generated/server";
-import { requireMember } from "../auth";
+import { getAuthContextOrNull, requireMember } from "../auth";
+import { buildPageTree } from "../lib/tree";
 
 // List pages for a site (authenticated — editor only)
 export const list = query({
@@ -19,25 +20,74 @@ export const list = query({
   },
 });
 
-// Get page by ID
+// Get page by ID (authenticated — requires team membership)
 export const get = query({
   args: { pageId: v.id("pages") },
   handler: async (ctx, { pageId }) => {
-    return await ctx.db.get(pageId);
+    const page = await ctx.db.get(pageId);
+    if (!page) return null;
+
+    // Verify the caller has access to this page's site
+    const site = await ctx.db.get(page.siteId);
+    if (!site) return null;
+
+    // Allow access if user is a team member OR site is published
+    const auth = await getAuthContextOrNull(ctx);
+    if (auth) {
+      // Authenticated user — check membership
+      const member = await ctx.db
+        .query("members")
+        .withIndex("by_team_user", (q) =>
+          q.eq("teamId", site.teamId).eq("userId", auth.userId),
+        )
+        .first();
+      if (member) return page;
+    }
+
+    // Not a member — only return if site is published and page is deployed
+    if (site.isPublished && page.isDeployed) {
+      return page;
+    }
+
+    return null;
   },
 });
 
-// Get page by slug
+// Get page by slug (authenticated or published)
 export const getBySlug = query({
   args: {
     siteId: v.id("sites"),
     slug: v.string(),
   },
   handler: async (ctx, { siteId, slug }) => {
-    return await ctx.db
+    const page = await ctx.db
       .query("pages")
       .withIndex("by_slug", (q) => q.eq("siteId", siteId).eq("slug", slug))
       .first();
+
+    if (!page) return null;
+
+    // Verify access
+    const site = await ctx.db.get(siteId);
+    if (!site) return null;
+
+    const auth = await getAuthContextOrNull(ctx);
+    if (auth) {
+      const member = await ctx.db
+        .query("members")
+        .withIndex("by_team_user", (q) =>
+          q.eq("teamId", site.teamId).eq("userId", auth.userId),
+        )
+        .first();
+      if (member) return page;
+    }
+
+    // Not a member — only return if site is published and page is deployed
+    if (site.isPublished && page.isDeployed) {
+      return page;
+    }
+
+    return null;
   },
 });
 
@@ -55,14 +105,13 @@ export const getChildren = query({
       )
       .collect();
 
-    // Sort by order
     pages.sort((a, b) => a.order - b.order);
 
     return pages;
   },
 });
 
-// Build page tree (for navigation)
+// Build page tree (for editor navigation — uses draft fields)
 export const getTree = query({
   args: { siteId: v.id("sites") },
   handler: async (ctx, { siteId }) => {
@@ -71,43 +120,18 @@ export const getTree = query({
       .withIndex("by_site", (q) => q.eq("siteId", siteId))
       .collect();
 
-    // Build tree structure
-    type PageWithChildren = (typeof allPages)[0] & {
-      children: PageWithChildren[];
-    };
-
-    const pageMap = new Map<string, PageWithChildren>();
-    const rootPages: PageWithChildren[] = [];
-
-    // First pass: create map with empty children
-    for (const page of allPages) {
-      pageMap.set(page._id, { ...page, children: [] });
-    }
-
-    // Second pass: build tree
-    for (const page of allPages) {
-      const pageWithChildren = pageMap.get(page._id)!;
-      if (page.parentId) {
-        const parent = pageMap.get(page.parentId);
-        if (parent) {
-          parent.children.push(pageWithChildren);
-        }
-      } else {
-        rootPages.push(pageWithChildren);
-      }
-    }
-
-    // Sort children by order
-    const sortChildren = (pages: PageWithChildren[]) => {
-      pages.sort((a, b) => a.order - b.order);
-      for (const page of pages) {
-        sortChildren(page.children);
-      }
-    };
-
-    sortChildren(rootPages);
-
-    return rootPages;
+    return buildPageTree(
+      allPages.map((page) => ({
+        _id: page._id,
+        siteId: page.siteId,
+        title: page.title,
+        slug: page.slug,
+        icon: page.icon,
+        order: page.order,
+        parentId: page.parentId,
+        pageTabs: page.pageTabs,
+      })),
+    );
   },
 });
 
@@ -133,7 +157,6 @@ export const getByPath = query({
       const slug = path[i]!;
       const isLast = i === path.length - 1;
 
-      // Find page with this slug under current parent
       const page = await ctx.db
         .query("pages")
         .withIndex("by_parent", (q) =>
@@ -178,7 +201,6 @@ export const getAncestors = query({
 
     let currentPage = await ctx.db.get(pageId);
 
-    // Walk up the parent chain
     while (currentPage?.parentId) {
       const parent = await ctx.db.get(currentPage.parentId);
       if (!parent) break;
@@ -207,30 +229,14 @@ export const getTreePublished = query({
       .withIndex("by_site", (q) => q.eq("siteId", siteId))
       .collect();
 
-    // Filter to only deployed pages, excluding subpage block content (accessed via side panel)
+    // Filter to only deployed pages, excluding subpage block content
     const deployedPages = allPages.filter(
       (p) => p.isDeployed && !p.isSubpageContent,
     );
 
-    // Build tree using published fields (fall back to draft for migration compat)
-    type PageNode = {
-      _id: string;
-      siteId: typeof siteId;
-      title: string;
-      slug: string;
-      icon?: string;
-      order: number;
-      parentId?: string;
-      pageTabs?: Array<{ id: string; label: string }>;
-      children: PageNode[];
-    };
-
-    const pageMap = new Map<string, PageNode>();
-    const rootPages: PageNode[] = [];
-
-    // First pass: create map
-    for (const page of deployedPages) {
-      pageMap.set(page._id, {
+    // Project to published fields (fall back to draft for migration compat)
+    return buildPageTree(
+      deployedPages.map((page) => ({
         _id: page._id,
         siteId: page.siteId,
         title: page.publishedTitle ?? page.title,
@@ -239,48 +245,18 @@ export const getTreePublished = query({
         order: page.publishedOrder ?? page.order,
         parentId: page.publishedParentId ?? page.parentId,
         pageTabs: page.publishedPageTabs ?? page.pageTabs,
-        children: [],
-      });
-    }
-
-    // Second pass: build tree
-    for (const node of pageMap.values()) {
-      if (node.parentId) {
-        const parent = pageMap.get(node.parentId);
-        if (parent) {
-          parent.children.push(node);
-        } else {
-          // Parent not deployed, treat as root
-          rootPages.push(node);
-        }
-      } else {
-        rootPages.push(node);
-      }
-    }
-
-    // Sort children by order
-    const sortChildren = (pages: PageNode[]) => {
-      pages.sort((a, b) => a.order - b.order);
-      for (const page of pages) {
-        sortChildren(page.children);
-      }
-    };
-
-    sortChildren(rootPages);
-
-    return rootPages;
+      })),
+    );
   },
 });
 
 // Get published page by nested path (for public routing)
-// Uses publishedSlug and publishedParentId to walk the tree
 export const getByPathPublished = query({
   args: {
     siteId: v.id("sites"),
     path: v.array(v.string()),
   },
   handler: async (ctx, { siteId, path }) => {
-    // Get all deployed pages for this site
     const allPages = await ctx.db
       .query("pages")
       .withIndex("by_site", (q) => q.eq("siteId", siteId))
@@ -291,25 +267,15 @@ export const getByPathPublished = query({
     // Empty path: resolve via site's defaultPageId, then fall back to first root page
     if (path.length === 0) {
       const site = await ctx.db.get(siteId);
-      // Prefer draft defaultPageId (user's current setting) over published (stale from last deploy)
       const resolvedDefaultPageId =
         site?.defaultPageId ?? site?.publishedDefaultPageId;
 
-      // Try the configured default page first
       if (resolvedDefaultPageId) {
         const defaultPage = deployedPages.find(
           (p) => p._id === resolvedDefaultPageId,
         );
         if (defaultPage) {
-          return {
-            ...defaultPage,
-            title: defaultPage.publishedTitle ?? defaultPage.title,
-            slug: defaultPage.publishedSlug ?? defaultPage.slug,
-            icon: defaultPage.publishedIcon ?? defaultPage.icon,
-            order: defaultPage.publishedOrder ?? defaultPage.order,
-            parentId: defaultPage.publishedParentId ?? defaultPage.parentId,
-            pageTabs: defaultPage.publishedPageTabs ?? defaultPage.pageTabs,
-          };
+          return projectPublishedPage(defaultPage);
         }
       }
 
@@ -322,19 +288,7 @@ export const getByPathPublished = query({
         );
 
       const firstPage = rootPages[0];
-      if (firstPage) {
-        return {
-          ...firstPage,
-          title: firstPage.publishedTitle ?? firstPage.title,
-          slug: firstPage.publishedSlug ?? firstPage.slug,
-          icon: firstPage.publishedIcon ?? firstPage.icon,
-          order: firstPage.publishedOrder ?? firstPage.order,
-          parentId: firstPage.publishedParentId ?? firstPage.parentId,
-          pageTabs: firstPage.publishedPageTabs ?? firstPage.pageTabs,
-        };
-      }
-
-      return null;
+      return firstPage ? projectPublishedPage(firstPage) : null;
     }
 
     // Walk the path from root to leaf using published fields
@@ -344,7 +298,6 @@ export const getByPathPublished = query({
       const slug = path[i]!;
       const isLast = i === path.length - 1;
 
-      // Find page with this published slug under current parent
       const page = deployedPages.find(
         (p) =>
           (p.publishedSlug ?? p.slug) === slug &&
@@ -364,16 +317,7 @@ export const getByPathPublished = query({
       }
 
       if (isLast) {
-        // Return with published fields projected as primary fields
-        return {
-          ...page,
-          title: page.publishedTitle ?? page.title,
-          slug: page.publishedSlug ?? page.slug,
-          icon: page.publishedIcon ?? page.icon,
-          order: page.publishedOrder ?? page.order,
-          parentId: page.publishedParentId ?? page.parentId,
-          pageTabs: page.publishedPageTabs ?? page.pageTabs,
-        };
+        return projectPublishedPage(page);
       }
 
       parentId = page._id;
@@ -390,7 +334,6 @@ export const getFullPath = query({
     const slugs: string[] = [];
     let currentPage = await ctx.db.get(pageId);
 
-    // Walk up to root, collecting slugs
     while (currentPage) {
       slugs.unshift(currentPage.slug);
       if (!currentPage.parentId) break;
@@ -400,3 +343,31 @@ export const getFullPath = query({
     return slugs.join("/");
   },
 });
+
+// Helper: project a page document to use published fields as primary
+function projectPublishedPage(page: {
+  _id: string;
+  title: string;
+  slug: string;
+  icon?: string;
+  order: number;
+  parentId?: string;
+  pageTabs?: Array<{ id: string; label: string }>;
+  publishedTitle?: string;
+  publishedSlug?: string;
+  publishedIcon?: string;
+  publishedOrder?: number;
+  publishedParentId?: string;
+  publishedPageTabs?: Array<{ id: string; label: string }>;
+  [key: string]: unknown;
+}) {
+  return {
+    ...page,
+    title: page.publishedTitle ?? page.title,
+    slug: page.publishedSlug ?? page.slug,
+    icon: page.publishedIcon ?? page.icon,
+    order: page.publishedOrder ?? page.order,
+    parentId: page.publishedParentId ?? page.parentId,
+    pageTabs: page.publishedPageTabs ?? page.pageTabs,
+  };
+}

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -126,6 +126,7 @@ export default defineSchema({
 
   // Layouts — content containers for blocks
   layouts: defineTable({
+    siteId: v.optional(v.id("sites")), // Denormalized for efficient site-wide queries
     pageId: v.id("pages"),
     tabId: v.optional(v.string()),
     type: layoutType,
@@ -145,6 +146,7 @@ export default defineSchema({
     createdAt: v.number(),
     updatedAt: v.number(),
   })
+    .index("by_site", ["siteId"])
     .index("by_page", ["pageId"])
     .index("by_page_tab", ["pageId", "tabId"]),
 

--- a/packages/backend/convex/search/queries.ts
+++ b/packages/backend/convex/search/queries.ts
@@ -2,6 +2,7 @@ import { v } from "convex/values";
 import type { Doc } from "../_generated/dataModel";
 import { query } from "../_generated/server";
 import { requireMember } from "../auth";
+import { getActiveLibraryIds } from "../lib/resolvers";
 
 // ============================================================================
 // Helper Functions
@@ -105,7 +106,7 @@ export const searchAll = query({
     // Search by title
     const titleResults = await ctx.db
       .query("searchableContent")
-      .withSearchIndex("search_title", (q: any) =>
+      .withSearchIndex("search_title", (q) =>
         q.search("title", trimmed).eq("siteId", siteId),
       )
       .take(limit * 2);
@@ -113,7 +114,7 @@ export const searchAll = query({
     // Search by content
     const contentResults = await ctx.db
       .query("searchableContent")
-      .withSearchIndex("search_content", (q: any) =>
+      .withSearchIndex("search_content", (q) =>
         q.search("extractedText", trimmed).eq("siteId", siteId),
       )
       .take(limit * 2);
@@ -172,36 +173,12 @@ export const searchAllPublic = query({
     const site = await ctx.db.get(siteId);
     if (!site || !site.isPublished) return [];
 
-    // Get active library IDs (libraries used in blocks on pages)
-    const pages = await ctx.db
-      .query("pages")
-      .withIndex("by_site", (q) => q.eq("siteId", siteId))
-      .collect();
-
-    const activeLibraryIds = new Set<string>();
-    for (const page of pages) {
-      const layouts = await ctx.db
-        .query("layouts")
-        .withIndex("by_page", (q) => q.eq("pageId", page._id))
-        .collect();
-
-      for (const layout of layouts) {
-        // ONLY use publishedSlots for public content - never fall back to draft
-        const slotsToCheck = layout.publishedSlots ?? [];
-        for (const slot of slotsToCheck) {
-          for (const block of slot.blocks) {
-            if (block.type === "library" && block.content?.libraryId) {
-              activeLibraryIds.add(block.content.libraryId);
-            }
-          }
-        }
-      }
-    }
+    const activeLibraryIds = await getActiveLibraryIds(ctx, siteId);
 
     // Search by title
     const titleResults = await ctx.db
       .query("searchableContent")
-      .withSearchIndex("search_title", (q: any) =>
+      .withSearchIndex("search_title", (q) =>
         q.search("title", trimmed).eq("siteId", siteId),
       )
       .take(limit * 2);
@@ -209,7 +186,7 @@ export const searchAllPublic = query({
     // Search by content
     const contentResults = await ctx.db
       .query("searchableContent")
-      .withSearchIndex("search_content", (q: any) =>
+      .withSearchIndex("search_content", (q) =>
         q.search("extractedText", trimmed).eq("siteId", siteId),
       )
       .take(limit * 2);
@@ -299,31 +276,7 @@ export const listTitlesPublic = query({
     const site = await ctx.db.get(siteId);
     if (!site || !site.isPublished) return [];
 
-    // Get active library IDs
-    const pages = await ctx.db
-      .query("pages")
-      .withIndex("by_site", (q) => q.eq("siteId", siteId))
-      .collect();
-
-    const activeLibraryIds = new Set<string>();
-    for (const page of pages) {
-      const layouts = await ctx.db
-        .query("layouts")
-        .withIndex("by_page", (q) => q.eq("pageId", page._id))
-        .collect();
-
-      for (const layout of layouts) {
-        // ONLY use publishedSlots - never fall back to draft
-        const slotsToCheck = layout.publishedSlots ?? [];
-        for (const slot of slotsToCheck) {
-          for (const block of slot.blocks) {
-            if (block.type === "library" && block.content?.libraryId) {
-              activeLibraryIds.add(block.content.libraryId);
-            }
-          }
-        }
-      }
-    }
+    const activeLibraryIds = await getActiveLibraryIds(ctx, siteId);
 
     const all = await ctx.db
       .query("searchableContent")


### PR DESCRIPTION
## Summary
- Eliminate all `as any` / `(q: any)` casts across 10 backend files (20+ instances)
- Fix security holes in `pages:get` and `pages:getBySlug` (now require auth or published+deployed)
- Add `siteId` to layouts schema with `by_site` index, fixing N+1 query patterns in deploy, rollback, banners, and public search
- Create `convex/lib/resolvers.ts` (typed entity resolution) and `convex/lib/tree.ts` (shared page tree building)
- Deduplicate `getActiveLibraryIds` (3 identical copies → 1 shared helper)
- Slim `editor-header.tsx` from 564 → 370 LOC (extract `HeaderPreview` component)
- Add migration 14 to backfill `siteId` on existing layouts

## Test plan
- [ ] Run `npx convex dev` to push schema changes
- [ ] Run migration 14 (`runBackfillLayoutSiteId`) to backfill siteId on existing layouts
- [ ] Verify deploy and rollback still work correctly
- [ ] Verify public site search returns correct results
- [ ] Verify editor header preview mode works
- [ ] Verify banners display on public pages