### PR TITLE
Add security hardening: CSP nonce, rate limiting, path validation

### DIFF
--- a/apps/web/app/api/storage/download/route.ts
+++ b/apps/web/app/api/storage/download/route.ts
@@ -18,13 +18,11 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    if (
-      path.includes("..") ||
-      path.includes("./") ||
-      path.includes(".\\") ||
-      path.includes("\\") ||
-      path.includes("\0")
-    ) {
+    // Intentionally unauthenticated: public-site visitors need media without a
+    // user session. Path obscurity (tenant + siteId + userId + timestamp)
+    // isolates tenants; this regex prevents path traversal and SSRF.
+    const VALID_PATH_RE = /^\/[a-zA-Z0-9_-]+(\/[a-zA-Z0-9_.%-]+)+$/;
+    if (!VALID_PATH_RE.test(path)) {
       return NextResponse.json({ error: "Invalid path" }, { status: 400 });
     }
 

--- a/apps/web/modules/media-viewer/media-viewer-modal.tsx
+++ b/apps/web/modules/media-viewer/media-viewer-modal.tsx
@@ -17,7 +17,7 @@ import {
   Music,
   X,
 } from "lucide-react";
-import { type ReactNode, useEffect, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useState } from "react";
 import { useMediaViewer } from "./context";
 import { getMediaFileType } from "./types";
 import { openInNewTab } from "./utils";
@@ -143,10 +143,12 @@ export function MediaViewerModal() {
     }
   };
 
-  // Callback for viewers to register their controls
-  const handleRenderControls = (controls: ReactNode) => {
+  // Stable callback for viewers to register their controls.
+  // useCallback prevents a new reference on every render, which would cause
+  // pdf-viewer and office-viewer useEffects to re-fire → infinite setState loop.
+  const handleRenderControls = useCallback((controls: ReactNode) => {
     setViewerControls(controls);
-  };
+  }, []);
 
   if (!isOpen || !currentFile) {
     return null;

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -2,6 +2,9 @@ import createNextIntlPlugin from "next-intl/plugin";
 
 const withNextIntl = createNextIntlPlugin("./i18n/request.ts");
 
+// CSP is generated per-request in proxy.ts with a cryptographic nonce.
+// Only non-CSP headers live here — these apply to ALL responses including
+// static files (_next/static) which the proxy matcher excludes.
 const securityHeaders = [
   { key: "X-Frame-Options", value: "DENY" },
   { key: "X-Content-Type-Options", value: "nosniff" },
@@ -13,22 +16,6 @@ const securityHeaders = [
   {
     key: "Strict-Transport-Security",
     value: "max-age=63072000; includeSubDomains; preload",
-  },
-  {
-    key: "Content-Security-Policy",
-    value: [
-      "default-src 'self'",
-      "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
-      "style-src 'self' 'unsafe-inline'",
-      "img-src 'self' data: blob: https:",
-      "font-src 'self' data:",
-      "connect-src 'self' https://*.convex.cloud wss://*.convex.cloud https://*.convex.site",
-      "frame-src https://view.officeapps.live.com https://docs.google.com",
-      "worker-src 'self' blob:",
-      "frame-ancestors 'none'",
-      "base-uri 'self'",
-      "form-action 'self'",
-    ].join("; "),
   },
 ];
 

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -79,6 +79,92 @@ function removeLocalePrefix(pathname: string): string {
   return pathname.replace(localePattern, "") || "/";
 }
 
+/**
+ * Build a strict per-request Content-Security-Policy header value.
+ *
+ * Production uses nonce + strict-dynamic (no unsafe-inline, no unsafe-eval).
+ * Development adds unsafe-eval because React uses eval() for error overlays.
+ *
+ * Why nonce-based instead of static:
+ *   A static CSP with 'unsafe-inline' offers no real XSS protection — any
+ *   injected script runs unchecked. A per-request cryptographic nonce means
+ *   only script/style elements we stamp get executed; injected markup is
+ *   blocked even if the attacker knows the policy.
+ *
+ * Why strict-dynamic:
+ *   Next.js loads page chunks dynamically via document.createElement('script').
+ *   strict-dynamic propagates trust from our nonce'd entry bundle to every
+ *   chunk it creates, without us maintaining an URL allowlist.
+ *
+ * style-src-elem vs style-src-attr:
+ *   We use style-src-attr 'unsafe-inline' (attribute-level inline styles only)
+ *   because the public-site customisation system applies dynamic CSS variables
+ *   via React's style={{}} prop — those become style="" attributes at render
+ *   time and cannot carry a nonce. style-src-elem remains strict (nonce only),
+ *   which is the more dangerous surface (injected <style> blocks).
+ */
+function buildCSP(nonce: string): string {
+  const isDev = process.env.NODE_ENV === "development";
+
+  const scriptSrc = [
+    "'self'",
+    `'nonce-${nonce}'`,
+    "'strict-dynamic'",
+    // PDF.js uses WebAssembly; wasm-unsafe-eval is narrower than unsafe-eval
+    // (allows Wasm compilation only, not arbitrary JS eval)
+    "'wasm-unsafe-eval'",
+    // React error overlay uses eval() in development only
+    ...(isDev ? ["'unsafe-eval'"] : []),
+  ].join(" ");
+
+  // Dev: add ws://localhost:* for Turbopack HMR websocket
+  const connectSrc = [
+    "'self'",
+    "https://*.convex.cloud",
+    "wss://*.convex.cloud",
+    "https://*.convex.site",
+    ...(isDev ? ["ws://localhost:*", "http://localhost:*"] : []),
+  ].join(" ");
+
+  return [
+    "default-src 'self'",
+    `script-src ${scriptSrc}`,
+    // <style> blocks require nonce; style="" attributes allowed for dynamic colours
+    `style-src-elem 'self' 'nonce-${nonce}'`,
+    "style-src-attr 'unsafe-inline'",
+    "img-src 'self' data: blob: https:",
+    "font-src 'self' data:",
+    `connect-src ${connectSrc}`,
+    "frame-src https://view.officeapps.live.com https://docs.google.com",
+    "worker-src 'self' blob:",
+    "object-src 'none'",
+    "frame-ancestors 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    // Only upgrade insecure requests in production; localhost is HTTP by design
+    ...(isDev ? [] : ["upgrade-insecure-requests"]),
+  ].join("; ");
+}
+
+/**
+ * Attach CSP header and forward the nonce to server components.
+ *
+ * Next.js reads x-middleware-request-{name} response headers and injects them
+ * as {name} request headers on the page — this is how NextResponse.next(
+ * { request: { headers } }) works internally, and what makes headers() in
+ * Server Components see the values set here.
+ */
+function withCSP(
+  response: NextResponse,
+  nonce: string,
+  csp: string,
+): NextResponse {
+  response.headers.set("Content-Security-Policy", csp);
+  // Forwarded to server components as the x-nonce request header
+  response.headers.set("x-middleware-request-x-nonce", nonce);
+  return response;
+}
+
 export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
   const host = request.headers.get("host") || "";
@@ -89,6 +175,10 @@ export async function proxy(request: NextRequest) {
     return NextResponse.next();
   }
 
+  // Per-request nonce — cryptographically random, base64-encoded UUID
+  const nonce = Buffer.from(crypto.randomUUID()).toString("base64");
+  const csp = buildCSP(nonce);
+
   // Handle path-based routing for vercel.app domains (/s/[subdomain]/...)
   // This is a fallback since wildcard subdomains don't work on vercel.app
   if (isVercelAppDomain(hostname)) {
@@ -98,10 +188,10 @@ export async function proxy(request: NextRequest) {
       const pathSuffix =
         pathBased.remainingPath === "/" ? "" : pathBased.remainingPath;
       url.pathname = `/${routing.defaultLocale}/site/${pathBased.subdomain}${pathSuffix}`;
-      return NextResponse.rewrite(url);
+      return withCSP(NextResponse.rewrite(url), nonce, csp);
     }
     // No path-based subdomain, continue to intl middleware
-    return intlMiddleware(request);
+    return withCSP(intlMiddleware(request), nonce, csp);
   }
 
   const subdomain = extractSubdomain(request);
@@ -109,7 +199,7 @@ export async function proxy(request: NextRequest) {
   // No subdomain = main app (landing, dashboard, auth)
   // Run the intl middleware for locale detection/routing
   if (!subdomain) {
-    return intlMiddleware(request);
+    return withCSP(intlMiddleware(request), nonce, csp);
   }
 
   // Check if it's a custom domain
@@ -119,7 +209,7 @@ export async function proxy(request: NextRequest) {
     const url = request.nextUrl.clone();
     const pathnameWithoutLocale = removeLocalePrefix(pathname);
     url.pathname = `/${routing.defaultLocale}/site/_custom/${encodeURIComponent(customDomain)}${pathnameWithoutLocale}`;
-    return NextResponse.rewrite(url);
+    return withCSP(NextResponse.rewrite(url), nonce, csp);
   }
 
   // Subdomain = published site
@@ -129,7 +219,11 @@ export async function proxy(request: NextRequest) {
     pathnameWithoutLocale.startsWith("/dashboard") ||
     pathnameWithoutLocale.startsWith("/onboarding")
   ) {
-    return NextResponse.redirect(new URL("/", request.url));
+    return withCSP(
+      NextResponse.redirect(new URL("/", request.url)),
+      nonce,
+      csp,
+    );
   }
 
   // Rewrite subdomain root to dynamic route /[locale]/site/[subdomain]/[...path]
@@ -137,7 +231,7 @@ export async function proxy(request: NextRequest) {
   const url = request.nextUrl.clone();
   const pathSuffix = pathnameWithoutLocale === "/" ? "" : pathnameWithoutLocale;
   url.pathname = `/${routing.defaultLocale}/site/${subdomain}${pathSuffix}`;
-  return NextResponse.rewrite(url);
+  return withCSP(NextResponse.rewrite(url), nonce, csp);
 }
 
 export const config = {

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "baseblocks",
@@ -69,6 +68,7 @@
       "dependencies": {
         "@convex-dev/better-auth": "^0.10.10",
         "@convex-dev/migrations": "^0.3.1",
+        "@convex-dev/rate-limiter": "^0.3.2",
         "better-auth": "^1.4.18",
         "convex": "^1.31.6",
         "convex-helpers": "^0.1.111",
@@ -225,6 +225,8 @@
     "@convex-dev/better-auth": ["@convex-dev/better-auth@0.10.10", "", { "dependencies": { "@better-auth/passkey": "1.4.9", "@better-fetch/fetch": "^1.1.18", "common-tags": "^1.8.2", "convex-helpers": "^0.1.95", "jose": "^6.1.0", "remeda": "^2.32.0", "semver": "^7.7.3", "type-fest": "^4.39.1", "zod": "^4.0.0" }, "peerDependencies": { "better-auth": "1.4.9", "convex": "^1.25.0", "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-BpwQ2kph43O7hmtGQAJ+ie3KrjONp83659QDjKDdH+X8yIdGevgehaqS5GHB0iJo7zQTtvs687GnAeLZ4Xx3/w=="],
 
     "@convex-dev/migrations": ["@convex-dev/migrations@0.3.1", "", { "peerDependencies": { "convex": "^1.24.8" } }, "sha512-dGiN82vWMN415/AGMcVooDOJk8iTousZahBBs27uA03pL74Uo3ksucUW3CiCfPx75rv+x9UnenEakimQYYNIrA=="],
+
+    "@convex-dev/rate-limiter": ["@convex-dev/rate-limiter@0.3.2", "", { "peerDependencies": { "convex": "^1.24.8", "react": "^18.2.0 || ^19.0.0" }, "optionalPeers": ["react"] }, "sha512-+oBPsBfFbzdxiF/9XaaTQmVnvDlvEfg/c69/v8LxTbw4VLuiflIKlfnPQL8OS0azXQQ11hcPWHmU8ytFmHKDXA=="],
 
     "@dagrejs/dagre": ["@dagrejs/dagre@1.1.8", "", { "dependencies": { "@dagrejs/graphlib": "2.2.4" } }, "sha512-5SEDlndt4W/LaVzPYJW+bSmSEZc9EzTf8rJ20WCKvjS5EAZAN0b+x0Yww7VMT4R3Wootkg+X9bUfUxazYw6Blw=="],
 

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -38,6 +38,7 @@ import type * as members_queries from "../members/queries.js";
 import type * as migrations from "../migrations.js";
 import type * as pages_mutations from "../pages/mutations.js";
 import type * as pages_queries from "../pages/queries.js";
+import type * as rateLimits from "../rateLimits.js";
 import type * as search_queries from "../search/queries.js";
 import type * as sharing_crypto from "../sharing/crypto.js";
 import type * as sharing_internal from "../sharing/internal.js";
@@ -86,6 +87,7 @@ declare const fullApi: ApiFromModules<{
   migrations: typeof migrations;
   "pages/mutations": typeof pages_mutations;
   "pages/queries": typeof pages_queries;
+  rateLimits: typeof rateLimits;
   "search/queries": typeof search_queries;
   "sharing/crypto": typeof sharing_crypto;
   "sharing/internal": typeof sharing_internal;
@@ -1660,6 +1662,140 @@ export declare const components: {
         },
         any
       >;
+    };
+  };
+  rateLimiter: {
+    lib: {
+      checkRateLimit: FunctionReference<
+        "query",
+        "internal",
+        {
+          config:
+            | {
+                capacity?: number;
+                kind: "token bucket";
+                maxReserved?: number;
+                period: number;
+                rate: number;
+                shards?: number;
+                start?: null;
+              }
+            | {
+                capacity?: number;
+                kind: "fixed window";
+                maxReserved?: number;
+                period: number;
+                rate: number;
+                shards?: number;
+                start?: number;
+              };
+          count?: number;
+          key?: string;
+          name: string;
+          reserve?: boolean;
+          throws?: boolean;
+        },
+        { ok: true; retryAfter?: number } | { ok: false; retryAfter: number }
+      >;
+      clearAll: FunctionReference<
+        "mutation",
+        "internal",
+        { before?: number },
+        null
+      >;
+      getServerTime: FunctionReference<"mutation", "internal", {}, number>;
+      getValue: FunctionReference<
+        "query",
+        "internal",
+        {
+          config:
+            | {
+                capacity?: number;
+                kind: "token bucket";
+                maxReserved?: number;
+                period: number;
+                rate: number;
+                shards?: number;
+                start?: null;
+              }
+            | {
+                capacity?: number;
+                kind: "fixed window";
+                maxReserved?: number;
+                period: number;
+                rate: number;
+                shards?: number;
+                start?: number;
+              };
+          key?: string;
+          name: string;
+          sampleShards?: number;
+        },
+        {
+          config:
+            | {
+                capacity?: number;
+                kind: "token bucket";
+                maxReserved?: number;
+                period: number;
+                rate: number;
+                shards?: number;
+                start?: null;
+              }
+            | {
+                capacity?: number;
+                kind: "fixed window";
+                maxReserved?: number;
+                period: number;
+                rate: number;
+                shards?: number;
+                start?: number;
+              };
+          shard: number;
+          ts: number;
+          value: number;
+        }
+      >;
+      rateLimit: FunctionReference<
+        "mutation",
+        "internal",
+        {
+          config:
+            | {
+                capacity?: number;
+                kind: "token bucket";
+                maxReserved?: number;
+                period: number;
+                rate: number;
+                shards?: number;
+                start?: null;
+              }
+            | {
+                capacity?: number;
+                kind: "fixed window";
+                maxReserved?: number;
+                period: number;
+                rate: number;
+                shards?: number;
+                start?: number;
+              };
+          count?: number;
+          key?: string;
+          name: string;
+          reserve?: boolean;
+          throws?: boolean;
+        },
+        { ok: true; retryAfter?: number } | { ok: false; retryAfter: number }
+      >;
+      resetRateLimit: FunctionReference<
+        "mutation",
+        "internal",
+        { key?: string; name: string },
+        null
+      >;
+    };
+    time: {
+      getServerTime: FunctionReference<"mutation", "internal", {}, number>;
     };
   };
 };

--- a/packages/backend/convex/convex.config.ts
+++ b/packages/backend/convex/convex.config.ts
@@ -1,9 +1,11 @@
 import migrations from "@convex-dev/migrations/convex.config.js";
+import rateLimiter from "@convex-dev/rate-limiter/convex.config.js";
 import { defineApp } from "convex/server";
 import betterAuth from "./betterAuth/convex.config";
 
 const app = defineApp();
 app.use(migrations);
 app.use(betterAuth);
+app.use(rateLimiter);
 
 export default app;

--- a/packages/backend/convex/rateLimits.ts
+++ b/packages/backend/convex/rateLimits.ts
@@ -1,0 +1,27 @@
+import { HOUR, MINUTE, RateLimiter } from "@convex-dev/rate-limiter";
+import { components } from "./_generated/api";
+
+/**
+ * Central rate limit definitions.
+ *
+ * All limits are keyed per-user (authenticated mutations) or per-resource
+ * (public mutations). Adjust numbers based on observed usage patterns.
+ */
+export const rateLimiter = new RateLimiter(components.rateLimiter, {
+  // --- Authenticated write operations ---
+
+  // Site creation: 20 sites per hour per user.
+  // Normal editorial workflow rarely exceeds a few per day.
+  createSite: { kind: "token bucket", rate: 20, period: HOUR },
+
+  // Team creation: 5 per hour per user.
+  // Onboarding creates one team; this allows a generous buffer.
+  createTeam: { kind: "token bucket", rate: 5, period: HOUR },
+
+  // --- Public mutations (no auth required) ---
+
+  // Password-protected site verification: 10 attempts per minute per site.
+  // Works alongside the existing per-access-code lockout (5 attempts / 15 min)
+  // to add a network-level defence against distributed brute-force.
+  verifyAccessCode: { kind: "fixed window", rate: 10, period: MINUTE },
+});

--- a/packages/backend/convex/sharing/crypto.ts
+++ b/packages/backend/convex/sharing/crypto.ts
@@ -7,11 +7,20 @@ const TOKEN_CHARS =
   "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
 
 function secureRandomChars(chars: string, length: number): string {
-  const array = new Uint32Array(length);
-  crypto.getRandomValues(array);
+  // Rejection sampling eliminates modulo bias.
+  // Values >= threshold are discarded and re-drawn so every char index is
+  // equally probable. Expected extra draws < 0.001% for our alphabet sizes.
+  const threshold = 0x100000000 - (0x100000000 % chars.length);
   let result = "";
-  for (let i = 0; i < length; i++) {
-    result += chars.charAt(array[i]! % chars.length);
+  while (result.length < length) {
+    const batch = new Uint32Array(length - result.length);
+    crypto.getRandomValues(batch);
+    for (const value of batch) {
+      if (value < threshold) {
+        result += chars.charAt(value % chars.length);
+        if (result.length === length) break;
+      }
+    }
   }
   return result;
 }

--- a/packages/backend/convex/sharing/mutations.ts
+++ b/packages/backend/convex/sharing/mutations.ts
@@ -1,6 +1,7 @@
 import { ConvexError, v } from "convex/values";
 import { mutation } from "../_generated/server";
 import { requireAdmin } from "../auth";
+import { rateLimiter } from "../rateLimits";
 
 // Visibility types
 const visibilityValidator = v.union(
@@ -101,6 +102,13 @@ export const verifyAccessCode = mutation({
     code: v.string(),
   },
   handler: async (ctx, { siteId, code }) => {
+    // Network-level rate limit: 10 attempts/minute per site, regardless of
+    // which access code is tried. Complements the per-code lockout below.
+    await rateLimiter.limit(ctx, "verifyAccessCode", {
+      key: siteId,
+      throws: true,
+    });
+
     const site = await ctx.db.get(siteId);
     if (!site) throw new Error("Site not found");
 

--- a/packages/backend/convex/sites/mutations.ts
+++ b/packages/backend/convex/sites/mutations.ts
@@ -3,6 +3,7 @@ import type { Id } from "../_generated/dataModel";
 import { mutation } from "../_generated/server";
 import { getAuthContext, requireAdmin } from "../auth";
 import { markSiteModified } from "../lib/markModified";
+import { rateLimiter } from "../rateLimits";
 
 // Create a new site
 export const create = mutation({
@@ -13,6 +14,11 @@ export const create = mutation({
   },
   handler: async (ctx, { name, slug, teamId: explicitTeamId }) => {
     const auth = await getAuthContext(ctx);
+
+    await rateLimiter.limit(ctx, "createSite", {
+      key: auth.userId,
+      throws: true,
+    });
 
     let resolvedTeamId: Id<"teams">;
 

--- a/packages/backend/convex/teams/mutations.ts
+++ b/packages/backend/convex/teams/mutations.ts
@@ -1,6 +1,7 @@
 import { v } from "convex/values";
 import { mutation } from "../_generated/server";
 import { getAuthContext, requireAdmin } from "../auth";
+import { rateLimiter } from "../rateLimits";
 
 export const create = mutation({
   args: {
@@ -10,6 +11,11 @@ export const create = mutation({
   },
   handler: async (ctx, { name, slug, organizationId }) => {
     const auth = await getAuthContext(ctx);
+
+    await rateLimiter.limit(ctx, "createTeam", {
+      key: auth.userId,
+      throws: true,
+    });
 
     // Check slug availability
     const existing = await ctx.db

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@convex-dev/better-auth": "^0.10.10",
     "@convex-dev/migrations": "^0.3.1",
+    "@convex-dev/rate-limiter": "^0.3.2",
     "better-auth": "^1.4.18",
     "convex": "^1.31.6",
     "convex-helpers": "^0.1.111"


### PR DESCRIPTION
## Summary

- **Nonce-based CSP**: Per-request cryptographic nonce generated in middleware (`proxy.ts`), forwarded to server components via `x-middleware-request-x-nonce`. Prevents inline script injection without blocking legitimate React usage.
- **Rate limiting**: `@convex-dev/rate-limiter` component with `createSite` (20/hr), `createTeam` (5/hr), `verifyAccessCode` (10/min per site) — per-user/per-resource keying.
- **Secure crypto**: `generateAccessCode` and `generateSessionToken` use rejection sampling to eliminate modulo bias in random character selection.
- **Path validation**: Strict regex allowlist on `/api/storage/download` prevents path traversal and SSRF.
- **Dev CSP fixes**: `wasm-unsafe-eval` for PDF.js WebAssembly, `ws://localhost:*` for Turbopack HMR, remove `upgrade-insecure-requests` in dev (breaks localhost HTTP).
- **Infinite re-render fix**: `handleRenderControls` wrapped in `useCallback` in `media-viewer-modal`.
- **Convex types regenerated**: `_generated/api.d.ts` updated to include `rateLimiter` component.

## Test plan

- [ ] Verify CSP nonce headers present in prod responses
- [ ] Verify PDF and Office viewers load without CSP violations
- [ ] Test password-protected site: verify rate limit kicks in after 10 attempts/min
- [ ] Test media viewer opens/closes without infinite loop errors
- [ ] Verify `/api/storage/download?path=../etc/passwd` returns 400