### PR TITLE
Fix spacebar not working inside editor blocks

### DIFF
--- a/apps/web/modules/editor/components/layouts/layout-renderer.tsx
+++ b/apps/web/modules/editor/components/layouts/layout-renderer.tsx
@@ -80,6 +80,7 @@ export function LayoutRenderer({
       }}
       onKeyDown={(e) => {
         if (e.key === "Enter" || e.key === " ") {
+          if (e.target !== e.currentTarget) return;
           e.preventDefault();
           e.stopPropagation();
           onSelectLayout();

--- a/apps/web/modules/editor/components/layouts/layout-slot.tsx
+++ b/apps/web/modules/editor/components/layouts/layout-slot.tsx
@@ -87,6 +87,7 @@ export function LayoutSlot({
       }}
       onKeyDown={(e) => {
         if (e.key === "Enter" || e.key === " ") {
+          if (e.target !== e.currentTarget) return;
           e.preventDefault();
           e.stopPropagation();
           onSelect();
@@ -215,6 +216,7 @@ function SortableBlock({
       }}
       onKeyDown={(e) => {
         if (e.key === "Enter" || e.key === " ") {
+          if (e.target !== e.currentTarget) return;
           e.preventDefault();
           e.stopPropagation();
           onSelect();

--- a/apps/web/modules/editor/components/page-editor.tsx
+++ b/apps/web/modules/editor/components/page-editor.tsx
@@ -281,6 +281,7 @@ export function PageEditor({
       onClick={handleEditorClick}
       onKeyDown={(e) => {
         if (e.key === "Enter" || e.key === " ") {
+          if (e.target !== e.currentTarget) return;
           e.preventDefault();
           handleEditorClick();
         }


### PR DESCRIPTION
## Summary
- `onKeyDown` handlers on `PageEditor`, `LayoutRenderer`, `LayoutSlot`, and `SortableBlock` wrapper divs were calling `preventDefault()` on spacebar events bubbling up from child editors (contentEditable divs, textareas)
- Added `e.target !== e.currentTarget` guard so spacebar selection is only triggered when the wrapper div itself is focused, not when typing in a child editor

## Test plan
- [ ] Type spacebar in any text/rich-text block — should insert a space
- [ ] Type spacebar in decision tree block — still works as before
- [ ] Click empty area of editor canvas — should still deselect (Enter/Space on focused wrapper)