### PR TITLE
chore: refresh Convex API after migration cleanup

### DIFF
--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -29,7 +29,6 @@ import type * as integrationWebhookSignature from "../integrationWebhookSignatur
 import type * as integrationWebhooks from "../integrationWebhooks.js";
 import type * as integrations from "../integrations.js";
 import type * as libraries from "../libraries.js";
-import type * as migrations from "../migrations.js";
 import type * as model_aiChangesetAudit from "../model/aiChangesetAudit.js";
 import type * as model_aiChangesetPlan from "../model/aiChangesetPlan.js";
 import type * as model_aiChangesetReferences from "../model/aiChangesetReferences.js";
@@ -96,7 +95,6 @@ declare const fullApi: ApiFromModules<{
   integrationWebhooks: typeof integrationWebhooks;
   integrations: typeof integrations;
   libraries: typeof libraries;
-  migrations: typeof migrations;
   "model/aiChangesetAudit": typeof model_aiChangesetAudit;
   "model/aiChangesetPlan": typeof model_aiChangesetPlan;
   "model/aiChangesetReferences": typeof model_aiChangesetReferences;


### PR DESCRIPTION
Removes the generated API reference to the deleted one-time migrations module. Convex codegen produced this diff during the verified strict-schema deployment.