### PR TITLE
Redesign billing and plans UI

### DIFF
--- a/apps/web/app/[locale]/(app)/dashboard/[teamSlug]/(workspace)/billing/plans/page.tsx
+++ b/apps/web/app/[locale]/(app)/dashboard/[teamSlug]/(workspace)/billing/plans/page.tsx
@@ -1,0 +1,5 @@
+import { BillingPage } from "@/features/dashboard/billing/billing-page";
+
+export default function BillingPlansRoute() {
+  return <BillingPage view="plans" />;
+}

--- a/apps/web/features/dashboard/billing/billing-credit-card.tsx
+++ b/apps/web/features/dashboard/billing/billing-credit-card.tsx
@@ -1,6 +1,5 @@
 import { Button } from "@baseblocks/ui/button";
 import { Card, CardContent } from "@baseblocks/ui/card";
-import { Label } from "@baseblocks/ui/label";
 import { useTranslations } from "next-intl";
 
 export type AiCreditTopUpOption = {
@@ -12,12 +11,14 @@ export type AiCreditTopUpOption = {
 
 export function BillingCreditCard({
   actionPending,
+  balance,
   creditTopUp,
   isPlus,
   locale,
   onCreditCheckout,
 }: {
   actionPending?: boolean;
+  balance: string;
   creditTopUp: AiCreditTopUpOption;
   isPlus: boolean;
   locale: string;
@@ -27,18 +28,26 @@ export function BillingCreditCard({
   return (
     <section aria-labelledby="billing-ai-credits" className="space-y-3">
       <div>
-        <h2 className="font-semibold" id="billing-ai-credits">
+        <h2 className="text-sm font-medium" id="billing-ai-credits">
           {t("credits.title")}
         </h2>
-        <p className="text-sm text-muted-foreground">
-          {t(isPlus ? "credits.plusDescription" : "credits.freeDescription")}
-        </p>
+        {isPlus ? (
+          <p className="text-sm text-muted-foreground">
+            {t("credits.plusDescription")}
+          </p>
+        ) : null}
       </div>
-      <Card className="gap-5 shadow-none">
-        <CardContent className="space-y-5">
-          <div className="space-y-2">
-            <Label>{t("credits.quickAmounts")}</Label>
-            <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+      <Card className="gap-0 border-0 py-0 shadow-none">
+        <CardContent className="p-0">
+          <div className="flex items-center justify-between gap-4 p-4">
+            <p className="text-sm font-medium">{t("credits.balance")}</p>
+            <p className="text-sm font-medium tabular-nums">
+              {t("current.aiBalance", { balance })}
+            </p>
+          </div>
+          <div className="space-y-3 border-t border-foreground/[0.06] p-4">
+            <p className="text-sm font-medium">{t("credits.quickAmounts")}</p>
+            <div className="flex flex-wrap gap-2">
               {creditTopUp.quickAmountsMinor.map((amountMinor) => {
                 const amount = new Intl.NumberFormat(locale, {
                   style: "currency",
@@ -68,11 +77,6 @@ export function BillingCreditCard({
                 {t("credits.customAmount")}
               </Button>
             </div>
-            <p className="text-xs text-muted-foreground">
-              {t("credits.customMinimum", {
-                minimum: Number(creditTopUp.minimumAmountMinor) / 100,
-              })}
-            </p>
           </div>
         </CardContent>
       </Card>

--- a/apps/web/features/dashboard/billing/billing-overview.tsx
+++ b/apps/web/features/dashboard/billing/billing-overview.tsx
@@ -1,21 +1,14 @@
 import { HugeiconsIcon } from "@hugeicons/react";
-import {
-  Alert02Icon,
-  CreditCardIcon,
-  SparklesIcon,
-  UserGroupIcon,
-} from "@hugeicons/core-free-icons";
-import { Badge } from "@baseblocks/ui/badge";
+import { Alert02Icon } from "@hugeicons/core-free-icons";
 import { Button } from "@baseblocks/ui/button";
 import {
-  Card,
-  CardAction,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "@baseblocks/ui/card";
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@baseblocks/ui/dialog";
 import { cn } from "@baseblocks/ui/lib/utils";
 import { useLocale, useTranslations } from "next-intl";
 import { useState } from "react";
@@ -43,6 +36,7 @@ export interface BillingOverviewProps {
   entitlement: WorkspaceBillingEntitlement;
   creditTopUp?: AiCreditTopUpOption;
   canManageBilling: boolean;
+  plansHref: string;
   plusOptions: PlusBillingOption[];
   onCheckout?: (sku: string) => void;
   onCreditCheckout?: (sku: string, amountMinor?: bigint) => void;
@@ -105,10 +99,49 @@ function BillingStatusCallout({
   );
 }
 
+function BillingSupportDialog() {
+  const t = useTranslations("billing.support");
+
+  return (
+    <Dialog>
+      <span>
+        {t("prompt")}{" "}
+        <DialogTrigger asChild>
+          <button
+            className="font-medium text-foreground underline decoration-foreground/30 underline-offset-2 transition-colors hover:decoration-foreground focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+            type="button"
+          >
+            {t("contact")}
+          </button>
+        </DialogTrigger>
+        .
+      </span>
+      <DialogContent className="overflow-hidden rounded-[1.5rem] border-sidebar-border bg-sidebar p-0 text-sidebar-foreground shadow-2xl sm:max-w-[28rem] [&_[data-slot='dialog-close']]:top-4 [&_[data-slot='dialog-close']]:right-4">
+        <DialogHeader className="px-5 pt-4 pb-0">
+          <DialogTitle className="text-base font-semibold">
+            {t("title")}
+          </DialogTitle>
+        </DialogHeader>
+        <DialogDescription className="px-5 pt-3 pb-5 text-left leading-relaxed text-sidebar-foreground/65">
+          {t("description")}{" "}
+          <a
+            className="font-medium text-sidebar-foreground underline decoration-sidebar-foreground/30 underline-offset-2 transition-colors hover:decoration-sidebar-foreground focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+            href="mailto:support@easylink.com"
+          >
+            support@easylink.com
+          </a>
+          .
+        </DialogDescription>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 export function BillingOverview({
   entitlement,
   creditTopUp,
   canManageBilling,
+  plansHref,
   plusOptions,
   onCheckout,
   onCreditCheckout,
@@ -139,8 +172,11 @@ export function BillingOverview({
     maximumFractionDigits: 2,
   }).format(Number(entitlement.availableAiCreditUnits) / 1_000_000);
   return (
-    <DashboardPage className="gap-5">
-      <DashboardPageHeader title={t("title")} />
+    <DashboardPage className="gap-8">
+      <DashboardPageHeader
+        description={<BillingSupportDialog />}
+        title={t("title")}
+      />
 
       <BillingStatusCallout
         callout={callout}
@@ -149,77 +185,53 @@ export function BillingOverview({
         onOpenPortal={onOpenPortal}
       />
 
-      <section aria-labelledby="billing-current-plan">
-        <Card className="gap-5 border-foreground/[0.07] shadow-none">
-          <CardHeader>
-            <CardTitle id="billing-current-plan">
-              {t("current.title")}
-            </CardTitle>
-            <CardDescription>
+      <section aria-labelledby="billing-current-plan" className="space-y-3">
+        <h2 className="text-sm font-medium" id="billing-current-plan">
+          {t("current.title")}
+        </h2>
+        <div className="flex flex-col gap-4 rounded-xl bg-card p-4 sm:flex-row sm:items-center">
+          <div className="min-w-0 flex-1">
+            <p className="text-sm font-medium">
+              {isPlus ? t("plans.plus.name") : t("plans.free.name")}
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              {t("current.memberCount", {
+                count: entitlement.billableSeatCount,
+              })}
               {isPlus
-                ? t("current.plusDescription")
-                : t("current.freeDescription")}
-            </CardDescription>
-            <CardAction>
-              <Badge variant={isPlus ? "default" : "secondary"}>
-                {isPlus ? t("plans.plus.name") : t("plans.free.name")}
-              </Badge>
-            </CardAction>
-          </CardHeader>
-          <CardContent className="grid gap-3 sm:grid-cols-3">
-            <div className="rounded-lg bg-muted/50 p-3">
-              <HugeiconsIcon
-                aria-hidden="true"
-                className="mb-2 size-5 text-muted-foreground"
-                icon={UserGroupIcon}
-              />
-              <p className="text-sm text-muted-foreground">
-                {t("current.members")}
-              </p>
-              <p className="mt-0.5 font-medium tabular-nums">
-                {entitlement.billableSeatCount}
-              </p>
-            </div>
-            <div className="rounded-lg bg-muted/50 p-3">
-              <HugeiconsIcon
-                aria-hidden="true"
-                className="mb-2 size-5 text-muted-foreground"
-                icon={CreditCardIcon}
-              />
-              <p className="text-sm text-muted-foreground">
-                {t("current.paidSeats")}
-              </p>
-              <p className="mt-0.5 font-medium tabular-nums">
-                {entitlement.paidSeatCapacity}
-              </p>
-            </div>
-            <div className="rounded-lg bg-muted/50 p-3">
-              <HugeiconsIcon
-                aria-hidden="true"
-                className="mb-2 size-5 text-muted-foreground"
-                icon={SparklesIcon}
-              />
-              <p className="text-sm text-muted-foreground">{t("current.ai")}</p>
-              <p className="mt-0.5 font-medium">
-                {t("current.aiBalance", { balance: aiBalance })}
-              </p>
-            </div>
-          </CardContent>
-          {additionalSeats > 0 || effectiveThrough ? (
-            <CardFooter className="flex-col items-start gap-1 text-sm text-muted-foreground">
-              {additionalSeats > 0 ? (
-                <p>
-                  {t("current.additionalSeats", { count: additionalSeats })}
-                </p>
-              ) : null}
-              {effectiveThrough ? (
-                <p>
-                  {t("current.effectiveThrough", { date: effectiveThrough })}
-                </p>
-              ) : null}
-            </CardFooter>
+                ? ` · ${t("current.paidSeatCount", {
+                    count: entitlement.paidSeatCapacity,
+                  })}`
+                : null}
+            </p>
+            {additionalSeats > 0 || effectiveThrough ? (
+              <div className="mt-1 space-y-0.5 text-xs text-muted-foreground">
+                {additionalSeats > 0 ? (
+                  <p>
+                    {t("current.additionalSeats", { count: additionalSeats })}
+                  </p>
+                ) : null}
+                {effectiveThrough ? (
+                  <p>
+                    {t("current.effectiveThrough", { date: effectiveThrough })}
+                  </p>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
+          {isPlus && canManageBilling && onOpenPortal ? (
+            <Button
+              className="shrink-0"
+              disabled={actionPending}
+              onClick={onOpenPortal}
+              size="sm"
+              type="button"
+              variant="outline"
+            >
+              {t("actions.manage")}
+            </Button>
           ) : null}
-        </Card>
+        </div>
       </section>
 
       <BillingPlanCards
@@ -228,8 +240,8 @@ export function BillingOverview({
         isPlus={isPlus}
         locale={locale}
         onCheckout={onCheckout}
-        onOpenPortal={onOpenPortal}
         onSelectPlusSku={setSelectedPlusSku}
+        plansHref={plansHref}
         plusOptions={plusOptions}
         selectedPlusOption={selectedPlusOption}
       />
@@ -237,6 +249,7 @@ export function BillingOverview({
       {creditTopUp ? (
         <BillingCreditCard
           actionPending={actionPending}
+          balance={aiBalance}
           creditTopUp={creditTopUp}
           isPlus={isPlus}
           locale={locale}

--- a/apps/web/features/dashboard/billing/billing-page.tsx
+++ b/apps/web/features/dashboard/billing/billing-page.tsx
@@ -6,9 +6,18 @@ import { Spinner } from "@baseblocks/ui/spinner";
 import { useAction, useConvexAuth, useQuery } from "convex/react";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
+import {
+  getTeamBillingPath,
+  getTeamBillingPlansPath,
+} from "@/features/dashboard/routes";
 import { BillingOverview } from "./billing-overview";
+import { BillingPlansPage } from "./billing-plans-page";
 
-export function BillingPage() {
+export function BillingPage({
+  view = "overview",
+}: {
+  view?: "overview" | "plans";
+}) {
   const { team } = useTeamAccess();
   const { isAuthenticated } = useConvexAuth();
   const queryArgs = isAuthenticated ? { organizationId: team._id } : "skip";
@@ -87,40 +96,57 @@ export function BillingPage() {
     }
   }
 
+  const onCheckout =
+    plusOptions.length > 0
+      ? (sku: string) => {
+          const checkoutKey =
+            checkoutKeysRef.current.get(sku) ?? crypto.randomUUID();
+          checkoutKeysRef.current.set(sku, checkoutKey);
+          const returnUrl = window.location.href;
+          void redirectToBilling(() =>
+            beginCheckout({
+              organizationId: team._id,
+              sku,
+              idempotencyKey: checkoutKey,
+              successUrl: `${returnUrl}${returnUrl.includes("?") ? "&" : "?"}checkout=success`,
+              returnUrl,
+            }),
+          );
+        }
+      : undefined;
+  const onOpenPortal = () => {
+    void redirectToBilling(() =>
+      openCustomerPortal({
+        organizationId: team._id,
+        returnUrl: window.location.href,
+      }),
+    );
+  };
+
+  if (view === "plans") {
+    return (
+      <BillingPlansPage
+        actionPending={actionPending}
+        billingHref={getTeamBillingPath(team.slug)}
+        canManageBilling={entitlement.canManageBilling}
+        entitlement={entitlement}
+        onCheckout={onCheckout}
+        onOpenPortal={onOpenPortal}
+        plusOptions={plusOptions}
+      />
+    );
+  }
+
   return (
     <BillingOverview
       actionPending={actionPending}
       canManageBilling={entitlement.canManageBilling}
       entitlement={entitlement}
       creditTopUp={creditTopUp}
+      plansHref={getTeamBillingPlansPath(team.slug)}
       plusOptions={plusOptions}
-      onCheckout={
-        plusOptions.length > 0
-          ? (sku) => {
-              const checkoutKey =
-                checkoutKeysRef.current.get(sku) ?? crypto.randomUUID();
-              checkoutKeysRef.current.set(sku, checkoutKey);
-              const returnUrl = window.location.href;
-              void redirectToBilling(() =>
-                beginCheckout({
-                  organizationId: team._id,
-                  sku,
-                  idempotencyKey: checkoutKey,
-                  successUrl: `${returnUrl}${returnUrl.includes("?") ? "&" : "?"}checkout=success`,
-                  returnUrl,
-                }),
-              );
-            }
-          : undefined
-      }
-      onOpenPortal={() => {
-        void redirectToBilling(() =>
-          openCustomerPortal({
-            organizationId: team._id,
-            returnUrl: window.location.href,
-          }),
-        );
-      }}
+      onCheckout={onCheckout}
+      onOpenPortal={onOpenPortal}
       onCreditCheckout={
         entitlement.canManageBilling
           ? (sku, amountMinor) => {

--- a/apps/web/features/dashboard/billing/billing-plan-cards.tsx
+++ b/apps/web/features/dashboard/billing/billing-plan-cards.tsx
@@ -1,17 +1,8 @@
-import { HugeiconsIcon } from "@hugeicons/react";
 import { CheckmarkCircle02Icon } from "@hugeicons/core-free-icons";
-import { Badge } from "@baseblocks/ui/badge";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { Button } from "@baseblocks/ui/button";
-import {
-  Card,
-  CardAction,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "@baseblocks/ui/card";
-import { cn } from "@baseblocks/ui/lib/utils";
+import { Switch } from "@baseblocks/ui/switch";
+import Link from "next/link";
 import { useTranslations } from "next-intl";
 
 export type PlusBillingOption = {
@@ -21,12 +12,57 @@ export type PlusBillingOption = {
   currency: string;
 };
 
+export function BillingIntervalSwitch({
+  disabled,
+  id,
+  onSelect,
+  options,
+  selectedOption,
+}: {
+  disabled?: boolean;
+  id: string;
+  onSelect: (sku: string) => void;
+  options: PlusBillingOption[];
+  selectedOption?: PlusBillingOption;
+}) {
+  const t = useTranslations("billing");
+  const monthlyOption = options.find(
+    (option) => option.recurringInterval === "month",
+  );
+  const yearlyOption = options.find(
+    (option) => option.recurringInterval === "year",
+  );
+  const isYearly = selectedOption?.recurringInterval === "year";
+
+  if (!monthlyOption || !yearlyOption) return null;
+
+  return (
+    <div className="flex items-center gap-2">
+      <Switch
+        checked={isYearly}
+        disabled={disabled}
+        id={id}
+        onCheckedChange={(checked) =>
+          onSelect(checked ? yearlyOption.sku : monthlyOption.sku)
+        }
+        size="sm"
+      />
+      <label
+        className="cursor-pointer text-xs font-normal text-muted-foreground peer-disabled:cursor-not-allowed peer-disabled:opacity-50"
+        htmlFor={id}
+      >
+        {t(isYearly ? "plans.plus.billedYearly" : "plans.plus.billedMonthly")}
+      </label>
+    </div>
+  );
+}
+
 function PlanFeature({ children }: { children: React.ReactNode }) {
   return (
-    <li className="flex gap-2 text-sm text-muted-foreground">
+    <li className="flex gap-2 text-xs text-muted-foreground">
       <HugeiconsIcon
         aria-hidden="true"
-        className="mt-0.5 size-4 shrink-0 text-foreground"
+        className="mt-px size-4 shrink-0 text-foreground"
         icon={CheckmarkCircle02Icon}
       />
       <span>{children}</span>
@@ -40,8 +76,8 @@ export function BillingPlanCards({
   isPlus,
   locale,
   onCheckout,
-  onOpenPortal,
   onSelectPlusSku,
+  plansHref,
   plusOptions,
   selectedPlusOption,
 }: {
@@ -50,138 +86,84 @@ export function BillingPlanCards({
   isPlus: boolean;
   locale: string;
   onCheckout?: (sku: string) => void;
-  onOpenPortal?: () => void;
   onSelectPlusSku: (sku: string) => void;
+  plansHref: string;
   plusOptions: PlusBillingOption[];
   selectedPlusOption?: PlusBillingOption;
 }) {
   const t = useTranslations("billing");
-  return (
-    <section
-      aria-labelledby="billing-plans"
-      className="grid gap-4 md:grid-cols-2"
-    >
-      <h2 className="sr-only" id="billing-plans">
-        {t("plans.title")}
-      </h2>
-      <Card
-        className={cn(
-          "gap-5 shadow-none",
-          !isPlus ? "border-foreground/20" : "border-foreground/[0.07]",
-        )}
-      >
-        <CardHeader>
-          <CardTitle>{t("plans.free.name")}</CardTitle>
-          <CardDescription>{t("plans.free.description")}</CardDescription>
-          {!isPlus ? (
-            <CardAction>
-              <Badge variant="outline">{t("plans.current")}</Badge>
-            </CardAction>
-          ) : null}
-        </CardHeader>
-        <CardContent>
-          <ul className="space-y-2">
-            <PlanFeature>{t("plans.free.features.sites")}</PlanFeature>
-            <PlanFeature>{t("plans.free.features.publishing")}</PlanFeature>
-            <PlanFeature>{t("plans.free.features.collaboration")}</PlanFeature>
-            <PlanFeature>{t("plans.free.features.ai")}</PlanFeature>
-          </ul>
-        </CardContent>
-      </Card>
+  const selectedPrice = selectedPlusOption
+    ? new Intl.NumberFormat(locale, {
+        style: "currency",
+        currency: selectedPlusOption.currency.toUpperCase(),
+        maximumFractionDigits: 0,
+      }).format(Number(selectedPlusOption.priceAmountMinor) / 100)
+    : null;
 
-      <Card
-        className={cn(
-          "gap-5 shadow-none",
-          isPlus ? "border-primary/40" : "border-foreground/[0.07]",
-        )}
-      >
-        <CardHeader>
-          <CardTitle>{t("plans.plus.name")}</CardTitle>
-          <CardDescription>{t("plans.plus.description")}</CardDescription>
-          {isPlus ? (
-            <CardAction>
-              <Badge>{t("plans.current")}</Badge>
-            </CardAction>
-          ) : null}
-        </CardHeader>
-        <CardContent>
-          {!isPlus && plusOptions.length > 0 ? (
-            <div className="mb-5 grid gap-2 sm:grid-cols-2">
-              {plusOptions.map((option) => {
-                const price = new Intl.NumberFormat(locale, {
-                  style: "currency",
-                  currency: option.currency.toUpperCase(),
-                  maximumFractionDigits: 0,
-                }).format(Number(option.priceAmountMinor) / 100);
-                const selected = option.sku === selectedPlusOption?.sku;
-                return (
-                  <Button
-                    aria-pressed={selected}
-                    className="h-auto justify-start px-3 py-2.5 text-left"
-                    key={option.sku}
-                    onClick={() => onSelectPlusSku(option.sku)}
-                    type="button"
-                    variant={selected ? "secondary" : "outline"}
-                  >
-                    <span>
-                      <span className="block font-medium">
-                        {t(`plans.plus.intervals.${option.recurringInterval}`)}
-                      </span>
-                      <span className="block text-xs font-normal text-muted-foreground">
-                        {t("plans.plus.pricePerMember", {
-                          price,
-                          interval: t(
-                            `plans.plus.intervalUnits.${option.recurringInterval}`,
-                          ),
-                        })}
-                      </span>
-                    </span>
-                  </Button>
-                );
-              })}
+  return (
+    <section aria-labelledby="billing-plans" className="space-y-3">
+      <div className="flex items-center justify-between gap-4">
+        <h2 className="text-sm font-medium" id="billing-plans">
+          {t("plans.title")}
+        </h2>
+        <Button asChild size="xs" variant="ghost">
+          <Link href={plansHref}>{t("plans.all")}</Link>
+        </Button>
+      </div>
+
+      {!isPlus ? (
+        <div className="rounded-xl bg-card p-4">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+            <div>
+              <p className="text-sm font-medium">{t("plans.upgradeTitle")}</p>
+              {selectedPlusOption && selectedPrice ? (
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {t("plans.plus.pricePerMember", {
+                    price: selectedPrice,
+                    interval: t(
+                      `plans.plus.intervalUnits.${selectedPlusOption.recurringInterval}`,
+                    ),
+                  })}
+                </p>
+              ) : null}
             </div>
-          ) : null}
-          <ul className="space-y-2">
+            <div className="flex flex-wrap items-center gap-2 sm:justify-end">
+              <BillingIntervalSwitch
+                disabled={actionPending}
+                id="billing-upgrade-yearly"
+                onSelect={onSelectPlusSku}
+                options={plusOptions}
+                selectedOption={selectedPlusOption}
+              />
+              {canManageBilling ? (
+                onCheckout && selectedPlusOption ? (
+                  <Button
+                    disabled={actionPending}
+                    onClick={() => onCheckout(selectedPlusOption.sku)}
+                    size="xs"
+                    type="button"
+                  >
+                    {t("actions.upgrade")}
+                  </Button>
+                ) : (
+                  <Button disabled size="xs" variant="outline">
+                    {t("actions.unavailable")}
+                  </Button>
+                )
+              ) : (
+                <p className="max-w-72 text-xs text-muted-foreground">
+                  {t("adminRequired")}
+                </p>
+              )}
+            </div>
+          </div>
+          <ul className="mt-4 grid gap-2 sm:grid-cols-3">
             <PlanFeature>{t("plans.plus.features.everything")}</PlanFeature>
             <PlanFeature>{t("plans.plus.features.ai")}</PlanFeature>
             <PlanFeature>{t("plans.plus.features.seats")}</PlanFeature>
           </ul>
-        </CardContent>
-        {canManageBilling ? (
-          <CardFooter>
-            {isPlus && onOpenPortal ? (
-              <Button
-                className="w-full"
-                disabled={actionPending}
-                onClick={onOpenPortal}
-                type="button"
-                variant="outline"
-              >
-                {t("actions.manage")}
-              </Button>
-            ) : !isPlus && onCheckout && selectedPlusOption ? (
-              <Button
-                className="w-full"
-                disabled={actionPending}
-                onClick={() => onCheckout(selectedPlusOption.sku)}
-                type="button"
-              >
-                {t("actions.upgrade")}
-              </Button>
-            ) : (
-              <Button className="w-full" disabled variant="outline">
-                {t("actions.unavailable")}
-              </Button>
-            )}
-          </CardFooter>
-        ) : (
-          <CardFooter>
-            <p className="text-sm text-muted-foreground">
-              {t("adminRequired")}
-            </p>
-          </CardFooter>
-        )}
-      </Card>
+        </div>
+      ) : null}
     </section>
   );
 }

--- a/apps/web/features/dashboard/billing/billing-plans-page.tsx
+++ b/apps/web/features/dashboard/billing/billing-plans-page.tsx
@@ -1,0 +1,276 @@
+import { ArrowLeft01Icon, Tick01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Button } from "@baseblocks/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@baseblocks/ui/table";
+import Link from "next/link";
+import { useLocale, useTranslations } from "next-intl";
+import { Fragment, useState } from "react";
+import {
+  DashboardPage,
+  DashboardPageHeader,
+} from "@/features/dashboard/layout/dashboard-page";
+import {
+  BillingIntervalSwitch,
+  type PlusBillingOption,
+} from "./billing-plan-cards";
+import { canUsePaidFeatures, type WorkspaceBillingEntitlement } from "./model";
+
+function Included() {
+  const t = useTranslations("billing.plans.comparison");
+
+  return (
+    <span className="inline-flex items-center gap-2 text-foreground">
+      <HugeiconsIcon aria-hidden icon={Tick01Icon} className="size-4" />
+      <span>{t("included")}</span>
+    </span>
+  );
+}
+
+export function BillingPlansPage({
+  actionPending,
+  billingHref,
+  canManageBilling,
+  entitlement,
+  onCheckout,
+  onOpenPortal,
+  plusOptions,
+}: {
+  actionPending?: boolean;
+  billingHref: string;
+  canManageBilling: boolean;
+  entitlement: WorkspaceBillingEntitlement;
+  onCheckout?: (sku: string) => void;
+  onOpenPortal?: () => void;
+  plusOptions: PlusBillingOption[];
+}) {
+  const t = useTranslations("billing");
+  const locale = useLocale();
+  const isPlus = canUsePaidFeatures(entitlement);
+  const [selectedPlusSku, setSelectedPlusSku] = useState(
+    plusOptions.find((option) => option.recurringInterval === "year")?.sku ??
+      plusOptions[0]?.sku,
+  );
+  const selectedPlusOption =
+    plusOptions.find((option) => option.sku === selectedPlusSku) ??
+    plusOptions[0];
+  const selectedPrice = selectedPlusOption
+    ? new Intl.NumberFormat(locale, {
+        style: "currency",
+        currency: selectedPlusOption.currency.toUpperCase(),
+        maximumFractionDigits: 0,
+      }).format(Number(selectedPlusOption.priceAmountMinor) / 100)
+    : null;
+
+  const featureGroups = [
+    {
+      title: t("plans.comparison.usage"),
+      rows: [
+        {
+          feature: t("plans.comparison.members"),
+          free: t("plans.comparison.unlimited"),
+          plus: t("plans.comparison.unlimited"),
+        },
+        {
+          feature: t("plans.comparison.ai"),
+          free: t("plans.comparison.prepaid"),
+          plus: t("plans.comparison.monthly"),
+        },
+        {
+          feature: t("plans.comparison.seats"),
+          free: t("plans.comparison.notIncluded"),
+          plus: <Included />,
+        },
+      ],
+    },
+    {
+      title: t("plans.comparison.core"),
+      rows: [
+        {
+          feature: t("plans.comparison.sites"),
+          free: <Included />,
+          plus: <Included />,
+        },
+        {
+          feature: t("plans.comparison.publishing"),
+          free: <Included />,
+          plus: <Included />,
+        },
+        {
+          feature: t("plans.comparison.collaboration"),
+          free: <Included />,
+          plus: <Included />,
+        },
+      ],
+    },
+  ];
+
+  return (
+    <DashboardPage className="gap-0">
+      <DashboardPageHeader
+        description={t("plans.currentSummary", {
+          plan: isPlus ? t("plans.plus.name") : t("plans.free.name"),
+        })}
+        leading={
+          <Button
+            asChild
+            className="size-7 shrink-0 rounded-lg"
+            size="icon-sm"
+            variant="ghost"
+          >
+            <Link
+              aria-label={t("actions.backToBilling")}
+              href={billingHref}
+              title={t("actions.backToBilling")}
+            >
+              <HugeiconsIcon aria-hidden icon={ArrowLeft01Icon} />
+            </Link>
+          </Button>
+        }
+        title={t("plans.title")}
+      />
+
+      <div className="-mx-4 overflow-x-auto px-4 pb-4 sm:-mx-6 sm:px-6">
+        <Table className="min-w-[48rem] table-fixed">
+          <TableHeader className="[&_tr]:border-foreground/[0.06]">
+            <TableRow className="hover:bg-transparent">
+              <TableHead className="h-auto w-[40%] p-0 align-top" />
+              <TableHead className="h-auto w-[30%] p-0 align-top font-normal">
+                <div className="space-y-4 px-6 py-6">
+                  <div>
+                    <p className="text-lg font-medium text-foreground">
+                      {t("plans.free.name")}
+                    </p>
+                    <p className="mt-1 text-sm text-foreground">
+                      <span className="font-semibold">
+                        {t("plans.free.price")}
+                      </span>{" "}
+                      <span className="text-xs text-muted-foreground">
+                        {t("plans.perMemberMonth")}
+                      </span>
+                    </p>
+                  </div>
+                  {isPlus && canManageBilling && onOpenPortal ? (
+                    <Button
+                      className="h-7 w-full rounded-md px-2.5 text-xs"
+                      disabled={actionPending}
+                      onClick={onOpenPortal}
+                      size="xs"
+                      type="button"
+                      variant="outline"
+                    >
+                      {t("actions.change")}
+                    </Button>
+                  ) : (
+                    <Button
+                      className="h-7 w-full rounded-md px-2.5 text-xs"
+                      disabled
+                      size="xs"
+                      variant="outline"
+                    >
+                      {t("plans.current")}
+                    </Button>
+                  )}
+                </div>
+              </TableHead>
+              <TableHead className="h-auto w-[30%] bg-card p-0 align-top font-normal">
+                <div className="space-y-4 px-6 py-6">
+                  <div>
+                    <p className="text-lg font-medium text-foreground">
+                      {t("plans.plus.name")}
+                    </p>
+                    <p className="mt-1 text-sm text-foreground">
+                      <span className="font-semibold">
+                        {selectedPrice ?? t("actions.unavailable")}
+                      </span>{" "}
+                      {selectedPrice ? (
+                        <span className="text-xs text-muted-foreground">
+                          {t("plans.perMember", {
+                            interval: t(
+                              `plans.plus.intervalUnits.${selectedPlusOption?.recurringInterval ?? "month"}`,
+                            ),
+                          })}
+                        </span>
+                      ) : null}
+                    </p>
+                  </div>
+                  <BillingIntervalSwitch
+                    disabled={actionPending}
+                    id="billing-plans-yearly"
+                    onSelect={setSelectedPlusSku}
+                    options={plusOptions}
+                    selectedOption={selectedPlusOption}
+                  />
+                  {isPlus ? (
+                    <Button
+                      className="h-7 w-full rounded-md px-2.5 text-xs"
+                      disabled
+                      size="xs"
+                      variant="secondary"
+                    >
+                      {t("plans.current")}
+                    </Button>
+                  ) : canManageBilling && onCheckout && selectedPlusOption ? (
+                    <Button
+                      className="h-7 w-full rounded-md px-2.5 text-xs"
+                      disabled={actionPending}
+                      onClick={() => onCheckout(selectedPlusOption.sku)}
+                      size="xs"
+                      type="button"
+                    >
+                      {t("actions.upgrade")}
+                    </Button>
+                  ) : (
+                    <Button
+                      className="h-7 w-full rounded-md px-2.5 text-xs"
+                      disabled
+                      size="xs"
+                      variant="outline"
+                    >
+                      {t("actions.unavailable")}
+                    </Button>
+                  )}
+                </div>
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {featureGroups.map((group) => (
+              <Fragment key={group.title}>
+                <TableRow className="border-0 hover:bg-transparent">
+                  <TableCell className="px-0 pt-8 pb-3 text-sm font-medium">
+                    {group.title}
+                  </TableCell>
+                  <TableCell />
+                  <TableCell className="bg-card" />
+                </TableRow>
+                {group.rows.map((row) => (
+                  <TableRow
+                    className="border-foreground/[0.06] hover:bg-muted/20"
+                    key={row.feature}
+                  >
+                    <TableCell className="py-3 pr-4 pl-0 font-normal whitespace-normal text-muted-foreground">
+                      {row.feature}
+                    </TableCell>
+                    <TableCell className="px-6 py-3 text-muted-foreground">
+                      {row.free}
+                    </TableCell>
+                    <TableCell className="bg-card px-6 py-3 text-muted-foreground">
+                      {row.plus}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </Fragment>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </DashboardPage>
+  );
+}

--- a/apps/web/features/dashboard/layout/dashboard-page.tsx
+++ b/apps/web/features/dashboard/layout/dashboard-page.tsx
@@ -47,9 +47,13 @@ export function DashboardPageState({
 
 export function DashboardPageHeader({
   action,
+  description,
+  leading,
   title,
 }: {
   action?: ReactNode;
+  description?: ReactNode;
+  leading?: ReactNode;
   title: ReactNode;
 }) {
   const t = useTranslations("navigation");
@@ -68,9 +72,17 @@ export function DashboardPageHeader({
                 title={t("toggleSidebar")}
               />
             ) : null}
-            <h1 className="brand-display truncate text-2xl leading-none font-normal tracking-[-0.025em]">
-              {title}
-            </h1>
+            {leading ? <div className="shrink-0">{leading}</div> : null}
+            <div className="min-w-0">
+              <h1 className="brand-display truncate text-2xl leading-none font-normal tracking-[-0.025em]">
+                {title}
+              </h1>
+              {description ? (
+                <div className="mt-1 text-xs leading-4 text-muted-foreground">
+                  {description}
+                </div>
+              ) : null}
+            </div>
           </div>
           {action ? <div className="shrink-0">{action}</div> : null}
         </div>

--- a/apps/web/features/dashboard/routes.ts
+++ b/apps/web/features/dashboard/routes.ts
@@ -18,6 +18,10 @@ export function getTeamBillingPath(teamSlug: string): string {
   return `${getTeamDashboardPath(teamSlug)}/billing`;
 }
 
+export function getTeamBillingPlansPath(teamSlug: string): string {
+  return `${getTeamBillingPath(teamSlug)}/plans`;
+}
+
 export function getTeamSiteEditorPath(
   teamSlug: string,
   siteId: string,

--- a/packages/i18n/src/messages/en.json
+++ b/packages/i18n/src/messages/en.json
@@ -515,13 +515,16 @@
   "billing": {
     "title": "Billing",
     "adminRequired": "Only workspace owners and admins can manage billing.",
+    "support": {
+      "prompt": "For questions about billing,",
+      "contact": "contact us",
+      "title": "Contact us",
+      "description": "Email us directly at"
+    },
     "current": {
       "title": "Current plan",
-      "freeDescription": "Your workspace is using the free plan.",
-      "plusDescription": "Your workspace has access to Plus features.",
-      "members": "Active members",
-      "paidSeats": "Paid seats",
-      "ai": "AI features",
+      "memberCount": "{count, plural, =1 {1 active member} other {# active members}}",
+      "paidSeatCount": "{count, plural, =1 {1 paid seat} other {# paid seats}}",
       "aiBalance": "{balance} available",
       "available": "Available",
       "unavailable": "Unavailable",
@@ -529,11 +532,16 @@
       "effectiveThrough": "Entitlement confirmed through {date}"
     },
     "plans": {
-      "title": "Available plans",
+      "title": "Plans",
+      "all": "All plans",
       "current": "Current plan",
+      "currentSummary": "You’re on the {plan} plan.",
+      "perMemberMonth": "per member/month",
+      "perMember": "per member/{interval}",
+      "upgradeTitle": "Upgrade to Plus",
       "free": {
         "name": "Free",
-        "description": "The essentials for a small workspace.",
+        "price": "$0",
         "features": {
           "sites": "Create and organize internal sites",
           "publishing": "Publish pages for your team",
@@ -543,7 +551,8 @@
       },
       "plus": {
         "name": "Plus",
-        "description": "More capacity and AI-assisted workflows for growing teams.",
+        "billedYearly": "Billed yearly",
+        "billedMonthly": "Billed monthly",
         "intervals": {
           "month": "Monthly",
           "year": "Annual"
@@ -558,18 +567,35 @@
           "ai": "Monthly AI credits that reset each billing period",
           "seats": "Paid seats for active workspace members"
         }
+      },
+      "comparison": {
+        "feature": "Feature",
+        "usage": "Usage",
+        "core": "Core features",
+        "members": "Members",
+        "sites": "Sites",
+        "publishing": "Publishing",
+        "collaboration": "Collaboration",
+        "ai": "AI credits",
+        "seats": "Paid seats",
+        "included": "Included",
+        "unlimited": "Unlimited",
+        "prepaid": "Prepaid",
+        "monthly": "Monthly + prepaid",
+        "notIncluded": "—"
       }
     },
     "credits": {
       "title": "AI credits",
-      "freeDescription": "Buy prepaid credits to use AI on Free. $1 paid adds $1 to your AI balance.",
-      "plusDescription": "Plus includes recurring credits. Add prepaid credits when you need more; purchased credits do not expire with the billing period.",
-      "quickAmounts": "Choose an amount",
-      "customAmount": "Custom amount",
-      "customMinimum": "Custom amounts are entered securely on Polar. Minimum ${minimum}."
+      "plusDescription": "Plus credits reset monthly. Purchased credits never expire.",
+      "balance": "Available balance",
+      "quickAmounts": "Add credits",
+      "customAmount": "Custom amount"
     },
     "actions": {
       "upgrade": "Upgrade to Plus",
+      "change": "Change plan",
+      "backToBilling": "Back to Billing",
       "manage": "Manage subscription",
       "resolve": "Review billing",
       "unavailable": "Billing unavailable"

--- a/packages/i18n/src/messages/fr.json
+++ b/packages/i18n/src/messages/fr.json
@@ -515,13 +515,16 @@
   "billing": {
     "title": "Facturation",
     "adminRequired": "Seuls les propriétaires et administrateurs de l’espace peuvent gérer la facturation.",
+    "support": {
+      "prompt": "Pour toute question sur la facturation,",
+      "contact": "contactez-nous",
+      "title": "Contactez-nous",
+      "description": "Écrivez-nous directement à"
+    },
     "current": {
       "title": "Offre actuelle",
-      "freeDescription": "Votre espace utilise l’offre gratuite.",
-      "plusDescription": "Votre espace bénéficie des fonctionnalités Plus.",
-      "members": "Membres actifs",
-      "paidSeats": "Sièges payants",
-      "ai": "Fonctionnalités IA",
+      "memberCount": "{count, plural, =1 {1 membre actif} other {# membres actifs}}",
+      "paidSeatCount": "{count, plural, =1 {1 siège payant} other {# sièges payants}}",
       "aiBalance": "{balance} disponibles",
       "available": "Disponibles",
       "unavailable": "Indisponibles",
@@ -529,11 +532,16 @@
       "effectiveThrough": "Droits confirmés jusqu’au {date}"
     },
     "plans": {
-      "title": "Offres disponibles",
+      "title": "Offres",
+      "all": "Toutes les offres",
       "current": "Offre actuelle",
+      "currentSummary": "Vous utilisez l’offre {plan}.",
+      "perMemberMonth": "par membre/mois",
+      "perMember": "par membre/{interval}",
+      "upgradeTitle": "Passer à Plus",
       "free": {
         "name": "Gratuite",
-        "description": "L’essentiel pour un petit espace de travail.",
+        "price": "0 $",
         "features": {
           "sites": "Créez et organisez des sites internes",
           "publishing": "Publiez des pages pour votre équipe",
@@ -543,7 +551,8 @@
       },
       "plus": {
         "name": "Plus",
-        "description": "Plus de capacité et des workflows assistés par l’IA pour les équipes en croissance.",
+        "billedYearly": "Facturation annuelle",
+        "billedMonthly": "Facturation mensuelle",
         "intervals": {
           "month": "Mensuel",
           "year": "Annuel"
@@ -558,18 +567,35 @@
           "ai": "Crédits IA mensuels réinitialisés à chaque période de facturation",
           "seats": "Sièges payants pour les membres actifs de l’espace"
         }
+      },
+      "comparison": {
+        "feature": "Fonctionnalité",
+        "usage": "Utilisation",
+        "core": "Fonctionnalités principales",
+        "members": "Membres",
+        "sites": "Sites",
+        "publishing": "Publication",
+        "collaboration": "Collaboration",
+        "ai": "Crédits IA",
+        "seats": "Sièges payants",
+        "included": "Inclus",
+        "unlimited": "Illimité",
+        "prepaid": "Prépayés",
+        "monthly": "Mensuels + prépayés",
+        "notIncluded": "—"
       }
     },
     "credits": {
       "title": "Crédits IA",
-      "freeDescription": "Achetez des crédits prépayés pour utiliser l’IA avec l’offre gratuite. 1 $ payé ajoute 1 $ à votre solde IA.",
-      "plusDescription": "Plus inclut des crédits récurrents. Ajoutez des crédits prépayés si nécessaire ; ils n’expirent pas avec la période de facturation.",
-      "quickAmounts": "Choisissez un montant",
-      "customAmount": "Montant personnalisé",
-      "customMinimum": "Le montant personnalisé est saisi de façon sécurisée sur Polar. Minimum ${minimum}."
+      "plusDescription": "Les crédits Plus sont renouvelés chaque mois. Les crédits achetés n’expirent jamais.",
+      "balance": "Solde disponible",
+      "quickAmounts": "Ajouter des crédits",
+      "customAmount": "Montant personnalisé"
     },
     "actions": {
       "upgrade": "Passer à Plus",
+      "change": "Changer d’offre",
+      "backToBilling": "Retour à la facturation",
       "manage": "Gérer l’abonnement",
       "resolve": "Vérifier la facturation",
       "unavailable": "Facturation indisponible"


### PR DESCRIPTION
## Summary
- simplify the billing overview and align its cards and actions with the rest of the dashboard
- add a dedicated full-page plans comparison route with monthly/yearly switching
- refine billing support, upgrade, and AI credit copy in English and French

## Validation
- `bunx biome check` on all changed source and translation files
- `bun run --filter @baseblocks/web check-types`
- `bun test apps/web/features/dashboard/billing/model.test.ts` (4 passed)
- `git diff --check`