### PR TITLE
Fix published images and page navigation

### DIFF
--- a/apps/web/features/published-sites/image-runtime.test.ts
+++ b/apps/web/features/published-sites/image-runtime.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { createPublishedImageRuntime } from "./image-runtime";
+
+describe("published OpenEditor image runtime", () => {
+  test("resolves only image IDs included in the published page", async () => {
+    const runtime = createPublishedImageRuntime(["released-image"]);
+
+    await expect(runtime.resolveImage?.("released-image")).resolves.toEqual({
+      imageId: "released-image",
+      src: "/api/files/released-image",
+      alt: "",
+      width: null,
+      height: null,
+    });
+    await expect(runtime.resolveImage?.("draft-image")).resolves.toBeNull();
+  });
+
+  test("stops before resolving when rendering is cancelled", async () => {
+    const runtime = createPublishedImageRuntime(["released-image"]);
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      runtime.resolveImage?.("released-image", { signal: controller.signal }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+  });
+});

--- a/apps/web/features/published-sites/image-runtime.ts
+++ b/apps/web/features/published-sites/image-runtime.ts
@@ -1,0 +1,21 @@
+import type { OpenEditorImageRuntime } from "@openeditor/core";
+
+export function createPublishedImageRuntime(
+  imageIds: readonly string[],
+): OpenEditorImageRuntime<File> {
+  const releasedImageIds = new Set(imageIds);
+
+  return {
+    resolveImage: async (imageId, { signal } = {}) => {
+      signal?.throwIfAborted();
+      if (!releasedImageIds.has(imageId)) return null;
+      return {
+        imageId,
+        src: `/api/files/${encodeURIComponent(imageId)}`,
+        alt: "",
+        width: null,
+        height: null,
+      };
+    },
+  };
+}

--- a/apps/web/features/published-sites/page-content.tsx
+++ b/apps/web/features/published-sites/page-content.tsx
@@ -17,7 +17,6 @@ import type {
 import { OpenEditorViewer } from "@openeditor/react";
 import { OpenEditorThemeProvider } from "@openeditor/ui";
 import "@openeditor/ui/styles.css";
-import { useMemo } from "react";
 import type { PublishedPageTarget } from "./page-targets";
 
 const EMPTY_PAGE_TARGETS = new Map<string, PublishedPageTarget>();
@@ -42,10 +41,7 @@ export function PublicPageContent({
   pageTargets = EMPTY_PAGE_TARGETS,
 }: PublicPageContentProps) {
   const actions = useSiteRenderActions();
-  const imageRuntime = useMemo(
-    () => createPublishedImageRuntime(imageIds),
-    [imageIds],
-  );
+  const imageRuntime = createPublishedImageRuntime(imageIds);
   const pageRuntime: OpenEditorPageRuntime = {
     resolvePage: async (targetPageId) => {
       const target = pageTargets.get(targetPageId);

--- a/apps/web/features/published-sites/page-content.tsx
+++ b/apps/web/features/published-sites/page-content.tsx
@@ -7,6 +7,7 @@ import { baseBlocksOpenEditorTheme } from "@/features/openeditor/openeditor-them
 import { OpenEditorTabbedPage } from "@/features/openeditor/page-tabs";
 import { readOpenEditorPageTabs } from "@/features/openeditor/page-tabs-model";
 import { publicSiteRenderers } from "@/features/openeditor/renderers";
+import { createPublishedImageRuntime } from "@/features/published-sites/image-runtime";
 import { getPageLink } from "@/features/published-sites/urls";
 import { Button } from "@baseblocks/ui/button";
 import type {
@@ -16,6 +17,7 @@ import type {
 import { OpenEditorViewer } from "@openeditor/react";
 import { OpenEditorThemeProvider } from "@openeditor/ui";
 import "@openeditor/ui/styles.css";
+import { useMemo } from "react";
 import type { PublishedPageTarget } from "./page-targets";
 
 const EMPTY_PAGE_TARGETS = new Map<string, PublishedPageTarget>();
@@ -26,6 +28,7 @@ interface PublicPageContentProps {
   onOpenPageBlock?: (pageId: string) => void;
   page: { icon?: string; title: string };
   content: OpenEditorDocument;
+  imageIds: readonly string[];
   pageTargets?: ReadonlyMap<string, PublishedPageTarget>;
 }
 
@@ -35,9 +38,14 @@ export function PublicPageContent({
   onOpenPageBlock,
   page,
   content,
+  imageIds,
   pageTargets = EMPTY_PAGE_TARGETS,
 }: PublicPageContentProps) {
   const actions = useSiteRenderActions();
+  const imageRuntime = useMemo(
+    () => createPublishedImageRuntime(imageIds),
+    [imageIds],
+  );
   const pageRuntime: OpenEditorPageRuntime = {
     resolvePage: async (targetPageId) => {
       const target = pageTargets.get(targetPageId);
@@ -81,6 +89,7 @@ export function PublicPageContent({
               <OpenEditorTabbedPage
                 document={content}
                 editable={false}
+                imageRuntime={imageRuntime}
                 pageRuntime={pageRuntime}
                 renderers={publicSiteRenderers}
               />
@@ -88,6 +97,7 @@ export function PublicPageContent({
               <OpenEditorViewer
                 className="oe-viewer"
                 document={content}
+                imageRuntime={imageRuntime}
                 pageRuntime={pageRuntime}
                 renderers={publicSiteRenderers}
               />

--- a/apps/web/features/published-sites/read-model.ts
+++ b/apps/web/features/published-sites/read-model.ts
@@ -76,7 +76,7 @@ async function queryReleaseLibraries(
 const queryPublicReleasePage = unstable_cache(
   (releaseId: Id<"siteReleases">, path: string) =>
     queryReleasePage(releaseId, path),
-  ["published-release-page-v2"],
+  ["published-release-page-v3"],
 );
 
 const queryPublicReleasePageMetadata = unstable_cache(
@@ -309,6 +309,7 @@ async function resolvePublishedPageUncached(
     ...siteResolution,
     page: page.page,
     content: page.content,
+    imageIds: page.imageIds ?? [],
     libraries,
     navigation,
     canonicalUrlInputs: {

--- a/apps/web/features/published-sites/shell.tsx
+++ b/apps/web/features/published-sites/shell.tsx
@@ -143,6 +143,7 @@ export function PublicSiteShell({ result }: PublicSiteShellProps) {
                 key={page._id}
                 page={navigationIcon ? { ...page, icon: navigationIcon } : page}
                 content={result.content}
+                imageIds={result.imageIds}
                 canGoBack={previousPageUrl !== null}
                 onGoBack={goBack}
                 onOpenPageBlock={openPageBlock}
@@ -485,8 +486,14 @@ function PublishedPageNavigation({
                 style={{ paddingInlineStart: `${depth * 0.75}rem` }}
                 className="flex h-8 min-w-0 gap-0 p-0 font-normal data-[active=true]:font-medium"
               >
-                <div>
-                  <span className="relative size-7 shrink-0">
+                <div className="relative">
+                  <Link
+                    aria-label={page.title}
+                    className="absolute inset-0 rounded-md outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+                    href={getPageLink(siteSlug, page.fullPath)}
+                    prefetch={false}
+                  />
+                  <span className="pointer-events-none relative z-10 size-7 shrink-0">
                     <span
                       aria-hidden="true"
                       className={cn(
@@ -501,7 +508,7 @@ function PublishedPageNavigation({
                       <button
                         type="button"
                         aria-label={`${isExpanded ? "Collapse" : "Expand"} ${page.title}`}
-                        className="absolute inset-0 z-10 flex items-center justify-center text-muted-foreground opacity-0 outline-none transition-opacity duration-100 ease-[cubic-bezier(0.2,0,0,1)] hover:text-foreground focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring group-hover/page:opacity-100 pointer-coarse:opacity-100"
+                        className="pointer-events-auto absolute inset-0 z-10 flex items-center justify-center text-muted-foreground opacity-0 outline-none transition-opacity duration-100 ease-[cubic-bezier(0.2,0,0,1)] hover:text-foreground focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring group-hover/page:opacity-100 pointer-coarse:opacity-100"
                         data-page-disclosure
                         onClick={() => {
                           disclosure.toggle(id);
@@ -519,17 +526,16 @@ function PublishedPageNavigation({
                   </span>
                   <OverflowTooltip content={page.title}>
                     {(textRef) => (
-                      <Link
-                        className="flex h-8 min-w-0 items-center overflow-hidden pr-2 outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
-                        href={getPageLink(siteSlug, page.fullPath)}
-                        prefetch={false}
+                      <span
+                        aria-hidden="true"
+                        className="pointer-events-none flex h-8 min-w-0 items-center overflow-hidden pr-2"
                       >
                         <MiddleTruncate
                           className="flex-1"
                           leadingRef={textRef}
                           text={page.title}
                         />
-                      </Link>
+                      </span>
                     )}
                   </OverflowTooltip>
                 </div>

--- a/packages/backend/convex/published.test.ts
+++ b/packages/backend/convex/published.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test } from "bun:test";
+import { getPage } from "./published";
+
+type RegisteredFunction = {
+  _handler: (ctx: unknown, args: unknown) => Promise<unknown>;
+};
+
+function invoke(fn: unknown, ctx: unknown, args: unknown): Promise<unknown> {
+  return (fn as RegisteredFunction)._handler(ctx, args);
+}
+
+describe("published page images", () => {
+  test("returns only referenced image assets captured by the live release", async () => {
+    const release = {
+      _id: "release-1",
+      siteId: "site-1",
+      defaultPageId: "page-1",
+    };
+    const site = {
+      _id: release.siteId,
+      organizationId: "organization-1",
+      liveReleaseId: release._id,
+      visibility: "public",
+    };
+    const page = {
+      _id: "release-page-1",
+      releaseId: release._id,
+      siteId: site._id,
+      pageId: release.defaultPageId,
+      title: "Home",
+      slug: "home",
+      parentId: undefined,
+      icon: undefined,
+      contentRevisionId: "revision-1",
+      updatedAt: 100,
+    };
+    const revision = {
+      _id: page.contentRevisionId,
+      payloadId: "payload-1",
+      fileIds: ["image-released", "file-not-image"],
+      libraryIds: [],
+      pageIds: [],
+    };
+    const payload = {
+      _id: revision.payloadId,
+      content: {
+        type: "doc",
+        version: 1,
+        content: [
+          {
+            type: "image",
+            attrs: {
+              "openeditor-id": "image-node-released",
+              imageId: "image-released",
+              src: null,
+              alt: "Released",
+            },
+          },
+          {
+            type: "image",
+            attrs: {
+              "openeditor-id": "image-node-draft",
+              imageId: "image-draft-only",
+              src: null,
+              alt: "Draft",
+            },
+          },
+          {
+            type: "image",
+            attrs: {
+              "openeditor-id": "image-node-wrong-kind",
+              imageId: "file-not-image",
+              src: null,
+              alt: "Wrong kind",
+            },
+          },
+        ],
+      },
+    };
+    const releaseFiles = new Map([
+      [
+        "image-released",
+        {
+          releaseId: release._id,
+          fileId: "image-released",
+          kind: "siteAsset",
+          contentType: "image/png",
+        },
+      ],
+      [
+        "file-not-image",
+        {
+          releaseId: release._id,
+          fileId: "file-not-image",
+          kind: "file",
+          contentType: "text/plain",
+        },
+      ],
+    ]);
+    const records = new Map<string, unknown>([
+      [release._id, release],
+      [site._id, site],
+      [revision._id, revision],
+      [payload._id, payload],
+    ]);
+    const ctx = {
+      db: {
+        get: async (id: string) => records.get(id) ?? null,
+        query: (table: string) => ({
+          withIndex: (
+            _index: string,
+            build: (query: {
+              eq: (field: string, value: string) => unknown;
+            }) => unknown,
+          ) => {
+            let fileId: string | undefined;
+            const query = {
+              eq(field: string, value: string) {
+                if (field === "fileId") fileId = value;
+                return query;
+              },
+            };
+            build(query);
+            return {
+              unique: async () =>
+                table === "releasePages"
+                  ? page
+                  : fileId
+                    ? (releaseFiles.get(fileId) ?? null)
+                    : null,
+            };
+          },
+        }),
+      },
+    };
+
+    const result = (await invoke(getPage, ctx, {
+      releaseId: release._id,
+      path: "",
+    })) as { imageIds?: string[] };
+
+    expect(result.imageIds).toEqual(["image-released"]);
+  });
+});

--- a/packages/backend/convex/published.ts
+++ b/packages/backend/convex/published.ts
@@ -158,6 +158,29 @@ export const getPage = query({
           return id ? [id] : [];
         })
         .sort();
+    const revisionFileIds = new Map(
+      (revision?.fileIds ?? []).map((fileId) => [String(fileId), fileId]),
+    );
+    const imageIds = (
+      await Promise.all(
+        Array.from(extractOpenEditorReferences(content).imageIds).map(
+          async (imageId) => {
+            const fileId = revisionFileIds.get(imageId);
+            if (!fileId) return null;
+            const asset = await ctx.db
+              .query("releaseFiles")
+              .withIndex("by_release_file", (q) =>
+                q.eq("releaseId", releaseId).eq("fileId", fileId),
+              )
+              .unique();
+            return asset?.kind === "siteAsset" &&
+              asset.contentType.toLowerCase().startsWith("image/")
+              ? imageId
+              : null;
+          },
+        ),
+      )
+    ).filter((imageId): imageId is string => imageId !== null);
 
     return {
       page: {
@@ -176,6 +199,7 @@ export const getPage = query({
         updatedAt: resolved.page.updatedAt,
       },
       content,
+      imageIds,
       libraryIds,
       canonicalPath: canonicalPagePath(context.release, resolved),
       updatedAt: resolved.page.updatedAt,


### PR DESCRIPTION
## What changed

- project released image IDs through the published page read model and resolve them with a read-only OpenEditor runtime
- restrict resolution to image assets captured by the immutable page revision and live release
- pass the runtime to normal and tabbed published viewers
- make the full published navigation row a semantic link while keeping disclosure controls independent
- bump the public release-page cache namespace for the new payload shape

## Root cause

The editor supplied OpenEditor with an image resolver, but the published renderer did not. OpenEditor correctly rejected persisted image URLs without a trusted resolver. Published navigation also wrapped only the visible label in a link, leaving the rest of the row inert.

## Validation

- 240 tests passed
- full workspace type-check passed
- production build passed with the configured development environment
- browser: released 600x600 image loaded through /api/files/{imageId}
- browser: clicking the empty far-right area of a navigation row navigated to the target page
