### PR TITLE
Standardize compact button sizing

### DIFF
--- a/apps/web/features/dashboard/billing/billing-credit-card.tsx
+++ b/apps/web/features/dashboard/billing/billing-credit-card.tsx
@@ -61,6 +61,7 @@ export function BillingCreditCard({
                     onClick={() =>
                       onCreditCheckout?.(creditTopUp.sku, amountMinor)
                     }
+                    size="compact"
                     type="button"
                     variant="outline"
                   >
@@ -71,6 +72,7 @@ export function BillingCreditCard({
               <Button
                 disabled={actionPending || !onCreditCheckout}
                 onClick={() => onCreditCheckout?.(creditTopUp.sku)}
+                size="compact"
                 type="button"
                 variant="outline"
               >

--- a/apps/web/features/dashboard/billing/billing-overview.tsx
+++ b/apps/web/features/dashboard/billing/billing-overview.tsx
@@ -88,7 +88,7 @@ function BillingStatusCallout({
         <Button
           disabled={actionPending}
           onClick={onOpenPortal}
-          size="sm"
+          size="compact"
           type="button"
           variant="outline"
         >
@@ -224,7 +224,7 @@ export function BillingOverview({
               className="shrink-0"
               disabled={actionPending}
               onClick={onOpenPortal}
-              size="sm"
+              size="compact"
               type="button"
               variant="outline"
             >

--- a/apps/web/features/dashboard/billing/billing-plan-cards.tsx
+++ b/apps/web/features/dashboard/billing/billing-plan-cards.tsx
@@ -106,7 +106,7 @@ export function BillingPlanCards({
         <h2 className="text-sm font-medium" id="billing-plans">
           {t("plans.title")}
         </h2>
-        <Button asChild size="xs" variant="ghost">
+        <Button asChild size="compact" variant="ghost">
           <Link href={plansHref}>{t("plans.all")}</Link>
         </Button>
       </div>
@@ -140,13 +140,13 @@ export function BillingPlanCards({
                   <Button
                     disabled={actionPending}
                     onClick={() => onCheckout(selectedPlusOption.sku)}
-                    size="xs"
+                    size="compact"
                     type="button"
                   >
                     {t("actions.upgrade")}
                   </Button>
                 ) : (
-                  <Button disabled size="xs" variant="outline">
+                  <Button disabled size="compact" variant="outline">
                     {t("actions.unavailable")}
                   </Button>
                 )

--- a/apps/web/features/dashboard/billing/billing-plans-page.tsx
+++ b/apps/web/features/dashboard/billing/billing-plans-page.tsx
@@ -158,10 +158,10 @@ export function BillingPlansPage({
                   </div>
                   {isPlus && canManageBilling && onOpenPortal ? (
                     <Button
-                      className="h-7 w-full rounded-md px-2.5 text-xs"
+                      className="w-full"
                       disabled={actionPending}
                       onClick={onOpenPortal}
-                      size="xs"
+                      size="compact"
                       type="button"
                       variant="outline"
                     >
@@ -169,9 +169,9 @@ export function BillingPlansPage({
                     </Button>
                   ) : (
                     <Button
-                      className="h-7 w-full rounded-md px-2.5 text-xs"
+                      className="w-full"
                       disabled
-                      size="xs"
+                      size="compact"
                       variant="outline"
                     >
                       {t("plans.current")}
@@ -209,28 +209,28 @@ export function BillingPlansPage({
                   />
                   {isPlus ? (
                     <Button
-                      className="h-7 w-full rounded-md px-2.5 text-xs"
+                      className="w-full"
                       disabled
-                      size="xs"
+                      size="compact"
                       variant="secondary"
                     >
                       {t("plans.current")}
                     </Button>
                   ) : canManageBilling && onCheckout && selectedPlusOption ? (
                     <Button
-                      className="h-7 w-full rounded-md px-2.5 text-xs"
+                      className="w-full"
                       disabled={actionPending}
                       onClick={() => onCheckout(selectedPlusOption.sku)}
-                      size="xs"
+                      size="compact"
                       type="button"
                     >
                       {t("actions.upgrade")}
                     </Button>
                   ) : (
                     <Button
-                      className="h-7 w-full rounded-md px-2.5 text-xs"
+                      className="w-full"
                       disabled
-                      size="xs"
+                      size="compact"
                       variant="outline"
                     >
                       {t("actions.unavailable")}

--- a/apps/web/features/dashboard/settings/account-section.tsx
+++ b/apps/web/features/dashboard/settings/account-section.tsx
@@ -81,8 +81,8 @@ export function AccountSection({ user }: { user: WorkspaceUser | null }) {
           {deletionPlan?.canDeleteAccount ? (
             <Button
               asChild
-              className="h-7 shrink-0 px-2.5 text-xs"
-              size="sm"
+              className="shrink-0"
+              size="compact"
               variant="destructive"
             >
               <Link href="/delete-account">
@@ -96,9 +96,9 @@ export function AccountSection({ user }: { user: WorkspaceUser | null }) {
             </Button>
           ) : (
             <Button
-              className="h-7 shrink-0 px-2.5 text-xs"
+              className="shrink-0"
               disabled
-              size="sm"
+              size="compact"
               variant="destructive"
             >
               {isLoading ? <Spinner className="size-4" /> : null}

--- a/apps/web/features/dashboard/settings/organization-management.tsx
+++ b/apps/web/features/dashboard/settings/organization-management.tsx
@@ -200,8 +200,7 @@ export function OrganizationManagement({
               <Button
                 disabled={working !== null}
                 form="workspace-details-form"
-                size="sm"
-                className="h-7 px-2.5 text-xs"
+                size="compact"
                 type="submit"
               >
                 {working === "save" ? <Spinner className="size-3.5" /> : null}
@@ -279,6 +278,7 @@ export function OrganizationManagement({
               <Button
                 disabled={!targetMemberId || working !== null}
                 onClick={() => setConfirm("transfer")}
+                size="compact"
                 type="button"
                 variant="outline"
               >
@@ -310,9 +310,10 @@ export function OrganizationManagement({
           </p>
           {!canDelete ? (
             <Button
-              className="h-7 shrink-0 px-2.5 text-xs"
+              className="shrink-0"
               disabled={working !== null}
               onClick={() => setConfirm("leave")}
+              size="compact"
               type="button"
               variant="outline"
             >
@@ -321,9 +322,10 @@ export function OrganizationManagement({
             </Button>
           ) : (
             <Button
-              className="h-7 shrink-0 px-2.5 text-xs"
+              className="shrink-0"
               disabled={working !== null}
               onClick={() => setConfirm("delete")}
+              size="compact"
               type="button"
               variant="destructive"
             >

--- a/apps/web/features/dashboard/settings/workspace-create-dialog.tsx
+++ b/apps/web/features/dashboard/settings/workspace-create-dialog.tsx
@@ -19,7 +19,6 @@ import {
 } from "@baseblocks/ui/dialog";
 import { Input } from "@baseblocks/ui/input";
 import { Label } from "@baseblocks/ui/label";
-import { cn } from "@baseblocks/ui/lib/utils";
 import { Spinner } from "@baseblocks/ui/spinner";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
@@ -95,12 +94,11 @@ export function WorkspaceCreateDialog({
       <DialogTrigger asChild>
         <Button
           aria-label={t("create")}
-          className={cn(
-            "h-7 px-2.5 text-xs",
-            compact && "size-7 px-0 sm:h-7 sm:w-auto sm:px-2.5",
-          )}
+          className={
+            compact ? "size-7 px-0 sm:h-7 sm:w-auto sm:px-2.5" : undefined
+          }
           disabled={disabled}
-          size="sm"
+          size="compact"
           title={compact ? t("create") : undefined}
         >
           <HugeiconsIcon icon={Add01Icon} className="size-4" />

--- a/apps/web/features/dashboard/sites/create-site-dialog.tsx
+++ b/apps/web/features/dashboard/sites/create-site-dialog.tsx
@@ -187,7 +187,7 @@ export function CreateSiteDialog({
         <Button
           className="product-primary-action rounded-[0.625rem]"
           disabled={disabled}
-          size="sm"
+          size="compact"
           type="button"
         >
           <HugeiconsIcon icon={Add01Icon} className="size-4" />

--- a/apps/web/features/dashboard/team/invite-member-dialog.tsx
+++ b/apps/web/features/dashboard/team/invite-member-dialog.tsx
@@ -146,7 +146,7 @@ export function InviteMemberDialog({
       <DialogTrigger asChild>
         <Button
           className="product-primary-action rounded-[0.625rem]"
-          size="sm"
+          size="compact"
           type="button"
         >
           <HugeiconsIcon icon={UserAdd01Icon} className="h-4 w-4" />

--- a/apps/web/features/marketing/landing-header.tsx
+++ b/apps/web/features/marketing/landing-header.tsx
@@ -5,15 +5,12 @@ interface LandingHeaderProps {
   locale: "en" | "fr";
 }
 
-const headerActionClassName = "w-[5.5rem]";
-
 export function LandingHeader({ labels, locale }: LandingHeaderProps) {
   const prefix = locale === "fr" ? "/fr" : "";
   const authAction = (
     <a
       className={marketingActionClassName({
-        className: headerActionClassName,
-        size: "sm",
+        size: "compact",
         variant: "default",
       })}
       href={`${prefix}/login`}

--- a/apps/web/features/marketing/landing-page.tsx
+++ b/apps/web/features/marketing/landing-page.tsx
@@ -61,7 +61,7 @@ export function LandingPage({ copy, labels, locale }: LandingPageProps) {
   const authCta = (
     <a
       className={marketingActionClassName({
-        size: "lg",
+        size: "compact",
         variant: "default",
       })}
       href={`${prefix}/login`}

--- a/apps/web/features/marketing/marketing-action.ts
+++ b/apps/web/features/marketing/marketing-action.ts
@@ -1,12 +1,11 @@
 import { cn } from "@baseblocks/ui/lib/utils";
 
 const baseClassName =
-  "inline-flex shrink-0 items-center justify-center whitespace-nowrap rounded-[0.625rem] text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50";
+  "inline-flex shrink-0 items-center justify-center whitespace-nowrap rounded-[0.625rem] font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50";
 
 const sizeClassNames = {
   icon: "size-9",
-  lg: "h-10 gap-2 px-6",
-  sm: "h-8 gap-1.5 px-3",
+  compact: "h-7 gap-1.5 px-2.5 text-xs",
 } as const;
 
 const variantClassNames = {

--- a/packages/ui/src/button.tsx
+++ b/packages/ui/src/button.tsx
@@ -22,6 +22,7 @@ const buttonVariants = cva(
       },
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",
+        compact: "h-7 gap-1.5 rounded-md px-2.5 text-xs has-[>svg]:px-2",
         xs: "h-6 gap-1 rounded-md px-2 text-xs has-[>svg]:px-1.5 [&_svg:not([class*='size-'])]:size-3",
         sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
         lg: "h-10 rounded-md px-6 has-[>svg]:px-4",


### PR DESCRIPTION
## Summary

- add a shared compact button size for refined product actions
- apply it consistently across dashboard billing, settings, site, and team actions
- align landing-page Sign In and Get Started actions to the same height, typography, and padding

## Why

Prominent actions used several different heights and text sizes, making Create Site, Invite Member, and landing CTAs feel heavier than the compact controls in billing and settings.

## Validation

- `bunx biome check` on all changed files
- `bun run check-types --filter=@baseblocks/web`
- verified rendered landing actions at 28px height, 12px/500 text, and 10px horizontal padding in the Codex browser