### PR TITLE
Fix checkout intent persistence

### DIFF
--- a/packages/backend/convex/billing/checkoutIntent.test.ts
+++ b/packages/backend/convex/billing/checkoutIntent.test.ts
@@ -4,10 +4,30 @@ import {
   checkoutAttemptCanAcquire,
   checkoutAttemptShouldReplay,
   MAX_CHECKOUT_RETRY_DELAY_MS,
+  newCheckoutIntentDocument,
 } from "./checkoutIntent";
 
 describe("checkout intent lifecycle", () => {
   const now = 1_000_000;
+
+  test("stores the active attempt without leaking command-only fields", () => {
+    const document = newCheckoutIntentDocument(
+      {
+        organizationId: "organization",
+        actorId: "actor",
+        providerEnvironment: "production",
+        purpose: "plus",
+        sku: "plus_annual",
+        requestedSeats: 8,
+        idempotencyKey: "checkout-key",
+        attemptId: "attempt-a",
+      },
+      now,
+    );
+
+    expect(document).not.toHaveProperty("attemptId");
+    expect(document.activeAttemptId).toBe("attempt-a");
+  });
 
   test("does not steal an active attempt lease", () => {
     expect(

--- a/packages/backend/convex/billing/checkoutIntent.ts
+++ b/packages/backend/convex/billing/checkoutIntent.ts
@@ -16,6 +16,41 @@ export type CheckoutIntentLifecycle = Readonly<{
   nextAttemptAt?: number;
 }>;
 
+type NewCheckoutIntentCommand = Readonly<{
+  organizationId: string;
+  actorId: string;
+  providerEnvironment: "sandbox" | "production";
+  purpose: "plus" | "aiCreditPack";
+  sku: string;
+  requestedSeats?: number;
+  requestedAmountMinor?: bigint;
+  idempotencyKey: string;
+  attemptId: string;
+}>;
+
+/** Projects command input into the persisted schema deliberately. */
+export function newCheckoutIntentDocument(
+  command: NewCheckoutIntentCommand,
+  now: number,
+) {
+  return {
+    organizationId: command.organizationId,
+    actorId: command.actorId,
+    providerEnvironment: command.providerEnvironment,
+    purpose: command.purpose,
+    sku: command.sku,
+    requestedSeats: command.requestedSeats,
+    requestedAmountMinor: command.requestedAmountMinor,
+    idempotencyKey: command.idempotencyKey,
+    status: "pending" as const,
+    attemptCount: 1,
+    activeAttemptId: command.attemptId,
+    leaseExpiresAt: now + CHECKOUT_ATTEMPT_LEASE_MS,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
 export function checkoutAttemptCanAcquire(
   intent: CheckoutIntentLifecycle,
   attemptId: string,

--- a/packages/backend/convex/billingModel.ts
+++ b/packages/backend/convex/billingModel.ts
@@ -4,6 +4,7 @@ import {
   CHECKOUT_ATTEMPT_LEASE_MS,
   checkoutAttemptCanAcquire,
   checkoutAttemptShouldReplay,
+  newCheckoutIntentDocument,
 } from "./billing/checkoutIntent";
 import {
   aiTopUpAmountToCreditUnits,
@@ -367,15 +368,10 @@ export const createCheckoutIntent = internalMutation({
       return await ctx.db.get(existing._id);
     }
     const now = Date.now();
-    const id = await ctx.db.insert("billingCheckoutIntents", {
-      ...args,
-      status: "pending",
-      attemptCount: 1,
-      activeAttemptId: args.attemptId,
-      leaseExpiresAt: now + CHECKOUT_ATTEMPT_LEASE_MS,
-      createdAt: now,
-      updatedAt: now,
-    });
+    const id = await ctx.db.insert(
+      "billingCheckoutIntents",
+      newCheckoutIntentDocument(args, now),
+    );
     return await ctx.db.get(id);
   },
 });


### PR DESCRIPTION
## Summary

- stop persisting the command-only `attemptId` field into `billingCheckoutIntents`
- explicitly project checkout commands into the Convex document schema
- add a regression test proving only `activeAttemptId` is stored

## Root cause

The checkout mutation used `{ ...args }` when creating a new intent. The refactor renamed the persisted field to `activeAttemptId`, but spreading the command also retained `attemptId`, so Convex rejected every new checkout before Polar was called.

## Validation

- exact production request traced in Convex logs
- regression test red before the fix and green after it
- 197 tests passed
- workspace typecheck passed
- Biome passed