### PR TITLE
Make editor loading atomic

### DIFF
--- a/apps/web/app/[locale]/(app)/layout.tsx
+++ b/apps/web/app/[locale]/(app)/layout.tsx
@@ -15,12 +15,13 @@ export const metadata: Metadata = {
 };
 
 export default async function AppLayout({ children }: PropsWithChildren) {
-  if (!(await getToken())) {
+  const [token, messages] = await Promise.all([getToken(), getMessages()]);
+
+  if (!token) {
     const locale = await getLocale();
     redirect({ href: "/login", locale });
   }
 
-  const messages = await getMessages();
   return (
     <NextIntlClientProvider
       messages={selectMessages(messages, [
@@ -45,7 +46,9 @@ export default async function AppLayout({ children }: PropsWithChildren) {
       ])}
     >
       <ProductThemeProvider>
-        <ConvexClientProvider>{children}</ConvexClientProvider>
+        <ConvexClientProvider initialToken={token}>
+          {children}
+        </ConvexClientProvider>
         <Toaster />
       </ProductThemeProvider>
     </NextIntlClientProvider>

--- a/apps/web/app/[locale]/(guest)/layout.tsx
+++ b/apps/web/app/[locale]/(guest)/layout.tsx
@@ -1,6 +1,7 @@
 import "@/app/product.css";
 import { ProductThemeProvider } from "@/components/product-theme-provider";
 import { selectMessages } from "@/i18n/messages";
+import { getToken } from "@/lib/auth/server";
 import { ConvexClientProvider } from "@/lib/convex/provider";
 import { Toaster } from "@baseblocks/ui/sonner";
 import { NextIntlClientProvider } from "next-intl";
@@ -8,7 +9,7 @@ import { getMessages } from "next-intl/server";
 import type { PropsWithChildren } from "react";
 
 export default async function GuestLayout({ children }: PropsWithChildren) {
-  const messages = await getMessages();
+  const [messages, token] = await Promise.all([getMessages(), getToken()]);
   return (
     <NextIntlClientProvider
       messages={selectMessages(messages, [
@@ -22,7 +23,9 @@ export default async function GuestLayout({ children }: PropsWithChildren) {
       ])}
     >
       <ProductThemeProvider>
-        <ConvexClientProvider>{children}</ConvexClientProvider>
+        <ConvexClientProvider initialToken={token}>
+          {children}
+        </ConvexClientProvider>
         <Toaster />
       </ProductThemeProvider>
     </NextIntlClientProvider>

--- a/apps/web/app/[locale]/(published)/layout.tsx
+++ b/apps/web/app/[locale]/(published)/layout.tsx
@@ -3,6 +3,7 @@ import {
   PublicConvexClientProvider,
 } from "@/lib/convex/provider";
 import "@/app/product.css";
+import { getToken } from "@/lib/auth/server";
 import { parseRequestHost } from "@/lib/routing/hosts";
 import type { ReactNode } from "react";
 import { selectMessages } from "@/i18n/messages";
@@ -16,9 +17,10 @@ export default async function PublicLayout({
 }: {
   children: ReactNode;
 }) {
-  const [messages, requestHeaders] = await Promise.all([
+  const [messages, requestHeaders, token] = await Promise.all([
     getMessages(),
     headers(),
+    getToken(),
   ]);
   const host =
     requestHeaders.get("x-forwarded-host") ?? requestHeaders.get("host") ?? "";
@@ -26,9 +28,6 @@ export default async function PublicLayout({
   const supportsTeamSession =
     parsedHost.kind === "subdomain" ||
     parsedHost.kind === "localhost-subdomain";
-  const Provider = supportsTeamSession
-    ? ConvexClientProvider
-    : PublicConvexClientProvider;
   return (
     <NextIntlClientProvider
       messages={selectMessages(messages, [
@@ -39,7 +38,13 @@ export default async function PublicLayout({
         "language",
       ])}
     >
-      <Provider>{children}</Provider>
+      {supportsTeamSession ? (
+        <ConvexClientProvider initialToken={token}>
+          {children}
+        </ConvexClientProvider>
+      ) : (
+        <PublicConvexClientProvider>{children}</PublicConvexClientProvider>
+      )}
       <Toaster />
     </NextIntlClientProvider>
   );

--- a/apps/web/features/editor/draft-restore-gate.tsx
+++ b/apps/web/features/editor/draft-restore-gate.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { api, type Doc, type Id } from "@baseblocks/backend";
+import { Button } from "@baseblocks/ui/button";
+import { Spinner } from "@baseblocks/ui/spinner";
+import { useMutation } from "convex/react";
+import { useState } from "react";
+import { toast } from "sonner";
+
+export interface DraftRestoreState {
+  _id: Id<"draftRestores">;
+  status: Doc<"draftRestores">["status"] | "orphaned";
+  failure?: string;
+}
+
+export function DraftRestoreGate({ restore }: { restore: DraftRestoreState }) {
+  const resume = useMutation(api.draftRestores.resume);
+  const cancel = useMutation(api.draftRestores.cancel);
+  const [resuming, setResuming] = useState(false);
+  const [cancelling, setCancelling] = useState(false);
+
+  return (
+    <div className="flex min-h-0 flex-1 items-center justify-center bg-background p-6">
+      <div className="max-w-md text-center">
+        {restore.status !== "paused" && restore.status !== "orphaned" ? (
+          <Spinner className="mx-auto size-6 text-muted-foreground" />
+        ) : null}
+        <h1 className="mt-4 text-base font-semibold">
+          {restore.status === "paused"
+            ? "Draft restore paused"
+            : restore.status === "orphaned"
+              ? "Draft restore needs recovery"
+              : restore.status === "validating"
+                ? "Checking historical version"
+                : "Restoring draft"}
+        </h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          {restore.status === "paused"
+            ? (restore.failure ??
+              "The restore paused after repeated failures. Resume it to continue safely.")
+            : restore.status === "orphaned"
+              ? restore.failure
+              : "The editor stays locked until the historical draft is coherent and ready."}
+        </p>
+        {restore.status === "paused" ? (
+          <Button
+            className="mt-4 rounded-full"
+            disabled={resuming}
+            onClick={async () => {
+              setResuming(true);
+              try {
+                await resume({ restoreId: restore._id });
+              } catch (error) {
+                setResuming(false);
+                toast.error(
+                  error instanceof Error
+                    ? error.message
+                    : "The restore could not resume",
+                );
+              }
+            }}
+          >
+            {resuming ? <Spinner /> : null}
+            Resume restore
+          </Button>
+        ) : null}
+        {restore.status === "validating" ? (
+          <Button
+            className="mt-4 rounded-full"
+            disabled={cancelling}
+            onClick={async () => {
+              setCancelling(true);
+              try {
+                await cancel({ restoreId: restore._id });
+              } catch (error) {
+                setCancelling(false);
+                toast.error(
+                  error instanceof Error
+                    ? error.message
+                    : "The restore could not be cancelled",
+                );
+              }
+            }}
+            variant="outline"
+          >
+            {cancelling ? <Spinner /> : null}
+            Cancel restore
+          </Button>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/features/editor/editor-reveal-boundary.test.tsx
+++ b/apps/web/features/editor/editor-reveal-boundary.test.tsx
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { EditorRevealBoundary } from "./editor-reveal-boundary";
+
+const themedEditor = <main data-site-theme="custom">Editor document</main>;
+
+describe("editor reveal boundary", () => {
+  test("keeps the themed editor unmounted while the snapshot loads", () => {
+    const markup = renderToStaticMarkup(
+      <EditorRevealBoundary state="loading">
+        {themedEditor}
+      </EditorRevealBoundary>,
+    );
+
+    expect(markup).not.toContain("data-site-theme");
+    expect(markup).not.toContain("Editor document");
+  });
+
+  test("reveals the editor only for a ready snapshot", () => {
+    expect(
+      renderToStaticMarkup(
+        <EditorRevealBoundary state="ready">
+          {themedEditor}
+        </EditorRevealBoundary>,
+      ),
+    ).toContain("Editor document");
+  });
+});

--- a/apps/web/features/editor/editor-reveal-boundary.tsx
+++ b/apps/web/features/editor/editor-reveal-boundary.tsx
@@ -1,0 +1,33 @@
+import { Empty, EmptyHeader, EmptyTitle } from "@baseblocks/ui/empty";
+import { Spinner } from "@baseblocks/ui/spinner";
+import type { ReactNode } from "react";
+
+export function EditorRevealBoundary({
+  children,
+  state,
+}: {
+  children?: ReactNode;
+  state: "loading" | "missing" | "ready";
+}) {
+  if (state === "loading") {
+    return (
+      <div className="flex min-h-0 flex-1 items-center justify-center bg-background">
+        <Spinner className="size-6 text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (state === "missing") {
+    return (
+      <Empty>
+        <EmptyHeader>
+          <EmptyTitle className="font-normal text-muted-foreground">
+            Site not found
+          </EmptyTitle>
+        </EmptyHeader>
+      </Empty>
+    );
+  }
+
+  return children;
+}

--- a/apps/web/features/editor/editor-state.tsx
+++ b/apps/web/features/editor/editor-state.tsx
@@ -2,8 +2,15 @@
 
 import { api, type Doc, type Id } from "@baseblocks/backend";
 import { useQuery } from "convex/react";
+import type { FunctionReturnType } from "convex/server";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { type ReactNode, createContext, use, useEffect, useState } from "react";
+import type { VersionedDocument } from "@/features/openeditor/versioned-document";
+import type { DraftRestoreState } from "./draft-restore-gate";
+
+type EditorSnapshot = NonNullable<
+  FunctionReturnType<typeof api.editorWorkspace.get>
+>;
 
 interface EditorPermissions {
   canEdit: boolean;
@@ -27,16 +34,14 @@ interface EditorSiteContextValue {
 }
 
 interface EditorWorkspaceContextValue {
-  status: "idle" | "loading" | "ready" | "missing";
+  status: "idle" | "loading" | "ready" | "restoring" | "missing";
   site: Doc<"sites"> | null;
   pages: Doc<"pages">[];
   selectedPage: Doc<"pages"> | null;
   selectedPageId: string | null;
-  restore: {
-    _id: Id<"draftRestores">;
-    status: Doc<"draftRestores">["status"] | "orphaned";
-    failure?: string;
-  } | null;
+  selectedDocument: (VersionedDocument & { pageId: Id<"pages"> }) | null;
+  draftSummary: EditorSnapshot["draftSummary"] | null;
+  restore: DraftRestoreState | null;
 }
 
 const EditorNavigationContext =
@@ -77,7 +82,13 @@ export function EditorProvider({
   const requestedPageId = searchParams.get("page");
   const workspace = useQuery(
     api.editorWorkspace.get,
-    siteId ? { organizationId, siteId: siteId as Id<"sites"> } : "skip",
+    siteId
+      ? {
+          organizationId,
+          siteId: siteId as Id<"sites">,
+          requestedPageId: requestedPageId ?? undefined,
+        }
+      : "skip",
   );
   const [historyState, setHistoryState] = useState<{
     siteId: string;
@@ -87,8 +98,7 @@ export function EditorProvider({
 
   const pages = workspace?.pages ?? [];
   const workspaceReady = workspace !== undefined && workspace !== null;
-  const selectedPage =
-    pages.find((page) => page._id === requestedPageId) ?? pages[0] ?? null;
+  const selectedPage = workspace?.selectedPage ?? null;
   const selectedPageId = selectedPage?._id ?? null;
 
   const replaceEditorUrl = (pageId: string | null) => {
@@ -161,11 +171,13 @@ export function EditorProvider({
         ? "loading"
         : workspace === null
           ? "missing"
-          : "ready",
+          : workspace.status,
     site: workspace?.site ?? null,
     pages,
     selectedPage,
     selectedPageId,
+    selectedDocument: workspace?.selectedDocument ?? null,
+    draftSummary: workspace?.draftSummary ?? null,
     restore: workspace?.restore ?? null,
   };
 

--- a/apps/web/features/editor/editor.tsx
+++ b/apps/web/features/editor/editor.tsx
@@ -5,19 +5,19 @@ import { useTeamAccess } from "@/features/authentication/team-access";
 import { useEditorWorkspace } from "@/features/editor/editor-state";
 import { OpenEditorPageEditor } from "@/features/openeditor/openeditor-page-editor";
 import { api } from "@baseblocks/backend";
-import type { Doc, Id } from "@baseblocks/backend";
+import type { Id } from "@baseblocks/backend";
 import type { SaveStatus } from "@baseblocks/domain";
-import { Button } from "@baseblocks/ui/button";
 import { PortalContainerProvider } from "@baseblocks/ui/contexts/portal-container-context";
 import { Empty, EmptyHeader, EmptyTitle } from "@baseblocks/ui/empty";
 import { cn } from "@baseblocks/ui/lib/utils";
 import { Spinner } from "@baseblocks/ui/spinner";
-import { useMutation, useQuery } from "convex/react";
+import { useMutation } from "convex/react";
 import dynamic from "next/dynamic";
 import { Suspense, useState } from "react";
 import { toast } from "sonner";
 import { EditorDialogs, type EditorDialogState } from "./editor-dialogs";
-import type { DraftSummary } from "./release-dialogs";
+import { DraftRestoreGate } from "./draft-restore-gate";
+import { EditorRevealBoundary } from "./editor-reveal-boundary";
 import { SiteHeaderContent } from "./site-header-content";
 
 const SiteAiChat = dynamic(() =>
@@ -38,7 +38,15 @@ function SiteEditorScreen({
   teamSlug,
 }: SiteEditorProps) {
   const { team } = useTeamAccess();
-  const { pages, restore, selectedPage, site, status } = useEditorWorkspace();
+  const {
+    draftSummary,
+    pages,
+    restore,
+    selectedDocument,
+    selectedPage,
+    site,
+    status,
+  } = useEditorWorkspace();
   const [isPreviewing, setIsPreviewing] = useState(false);
   const [saveStatus, setSaveStatus] = useState<SaveStatus>("idle");
   const [activeDialog, setActiveDialog] = useState<EditorDialogState | null>(
@@ -50,9 +58,6 @@ function SiteEditorScreen({
     null,
   );
 
-  const draftSummaryQuery = useQuery(api.releases.getDraftSummary, {
-    siteId: siteId as Id<"sites">,
-  });
   const unpublishSite = useMutation(api.releases.unpublish);
 
   const handleUnpublish = async () => {
@@ -64,45 +69,41 @@ function SiteEditorScreen({
     }
   };
 
-  if (status === "loading" || draftSummaryQuery === undefined) {
-    return <EditorLoading />;
+  if (status === "loading") {
+    return <EditorRevealBoundary state="loading" />;
   }
 
-  if (!site || !draftSummaryQuery || site.organizationId !== team._id) {
-    return (
-      <Empty>
+  if (!site || !draftSummary || site.organizationId !== team._id) {
+    return <EditorRevealBoundary state="missing" />;
+  }
+
+  const pageEditor =
+    selectedPage && selectedDocument?.pageId === selectedPage._id ? (
+      <OpenEditorPageEditor
+        authoritativeRefreshRevision={aiApplyRevision}
+        key={selectedPage._id}
+        onSaveStatusChange={setSaveStatus}
+        pageId={selectedPage._id}
+        pages={pages}
+        preview={isPreviewing}
+        remoteDocument={{
+          contentHash: selectedDocument.contentHash,
+          document: selectedDocument.document,
+        }}
+        siteId={site._id}
+      />
+    ) : (
+      <Empty className="min-h-[50vh]">
         <EmptyHeader>
           <EmptyTitle className="font-normal text-muted-foreground">
-            Site not found
+            Select a page to edit
           </EmptyTitle>
         </EmptyHeader>
       </Empty>
     );
-  }
-
-  const draftSummary = draftSummaryQuery as DraftSummary;
-  const pageEditor = selectedPage ? (
-    <OpenEditorPageEditor
-      authoritativeRefreshRevision={aiApplyRevision}
-      key={selectedPage._id}
-      onSaveStatusChange={setSaveStatus}
-      pageId={selectedPage._id}
-      pages={pages}
-      preview={isPreviewing}
-      siteId={site._id}
-    />
-  ) : (
-    <Empty className="min-h-[50vh]">
-      <EmptyHeader>
-        <EmptyTitle className="font-normal text-muted-foreground">
-          Select a page to edit
-        </EmptyTitle>
-      </EmptyHeader>
-    </Empty>
-  );
 
   return (
-    <>
+    <EditorRevealBoundary state="ready">
       {restore ? (
         <DraftRestoreGate restore={restore} />
       ) : (
@@ -185,109 +186,14 @@ function SiteEditorScreen({
         siteSlug={site.slug}
         teamSlug={team.slug}
       />
-    </>
-  );
-}
-
-function DraftRestoreGate({
-  restore,
-}: {
-  restore: {
-    _id: Id<"draftRestores">;
-    status: Doc<"draftRestores">["status"] | "orphaned";
-    failure?: string;
-  };
-}) {
-  const resume = useMutation(api.draftRestores.resume);
-  const cancel = useMutation(api.draftRestores.cancel);
-  const [resuming, setResuming] = useState(false);
-  const [cancelling, setCancelling] = useState(false);
-
-  return (
-    <div className="flex min-h-0 flex-1 items-center justify-center bg-background p-6">
-      <div className="max-w-md text-center">
-        {restore.status !== "paused" && restore.status !== "orphaned" ? (
-          <Spinner className="mx-auto size-6 text-muted-foreground" />
-        ) : null}
-        <h1 className="mt-4 text-base font-semibold">
-          {restore.status === "paused"
-            ? "Draft restore paused"
-            : restore.status === "orphaned"
-              ? "Draft restore needs recovery"
-              : restore.status === "validating"
-                ? "Checking historical version"
-                : "Restoring draft"}
-        </h1>
-        <p className="mt-2 text-sm text-muted-foreground">
-          {restore.status === "paused"
-            ? (restore.failure ??
-              "The restore paused after repeated failures. Resume it to continue safely.")
-            : restore.status === "orphaned"
-              ? restore.failure
-              : "The editor stays locked until the historical draft is coherent and ready."}
-        </p>
-        {restore.status === "paused" ? (
-          <Button
-            className="mt-4 rounded-full"
-            disabled={resuming}
-            onClick={async () => {
-              setResuming(true);
-              try {
-                await resume({ restoreId: restore._id });
-              } catch (error) {
-                setResuming(false);
-                toast.error(
-                  error instanceof Error
-                    ? error.message
-                    : "The restore could not resume",
-                );
-              }
-            }}
-          >
-            {resuming ? <Spinner /> : null}
-            Resume restore
-          </Button>
-        ) : null}
-        {restore.status === "validating" ? (
-          <Button
-            className="mt-4 rounded-full"
-            disabled={cancelling}
-            onClick={async () => {
-              setCancelling(true);
-              try {
-                await cancel({ restoreId: restore._id });
-              } catch (error) {
-                setCancelling(false);
-                toast.error(
-                  error instanceof Error
-                    ? error.message
-                    : "The restore could not be cancelled",
-                );
-              }
-            }}
-            variant="outline"
-          >
-            {cancelling ? <Spinner /> : null}
-            Cancel restore
-          </Button>
-        ) : null}
-      </div>
-    </div>
+    </EditorRevealBoundary>
   );
 }
 
 export function SiteEditor(props: SiteEditorProps) {
   return (
-    <Suspense fallback={<EditorLoading />}>
+    <Suspense fallback={<EditorRevealBoundary state="loading" />}>
       <SiteEditorScreen {...props} />
     </Suspense>
-  );
-}
-
-function EditorLoading() {
-  return (
-    <div className="flex min-h-0 flex-1 items-center justify-center bg-background">
-      <Spinner className="size-6 text-muted-foreground" />
-    </div>
   );
 }

--- a/apps/web/features/guests/guest-page.tsx
+++ b/apps/web/features/guests/guest-page.tsx
@@ -5,7 +5,7 @@ import { GuestEditorProvider } from "@/features/editor/editor-state";
 import { Link } from "@/i18n/navigation";
 import { workspaceApi } from "@/lib/convex/workspace-api";
 import { OpenEditorPageEditor } from "@/features/openeditor/openeditor-page-editor";
-import type { Doc, Id } from "@baseblocks/backend";
+import { api, type Doc, type Id } from "@baseblocks/backend";
 import { Empty, EmptyHeader, EmptyTitle } from "@baseblocks/ui/empty";
 import { Spinner } from "@baseblocks/ui/spinner";
 import { useQuery } from "convex/react";
@@ -26,14 +26,17 @@ export function GuestPage({ pageId }: { pageId: string }) {
   const result = useQuery(workspaceApi.pageGuests.getGuestWorkspace, {
     pageId: pageId as Id<"pages">,
   }) as GuestWorkspace | null | undefined;
-  if (result === undefined) {
+  const selectedDocument = useQuery(api.pageContent.getVersioned, {
+    pageId: pageId as Id<"pages">,
+  });
+  if (result === undefined || selectedDocument === undefined) {
     return (
       <div className="flex min-h-screen items-center justify-center">
         <Spinner className="size-5" />
       </div>
     );
   }
-  if (!result) {
+  if (!result || !selectedDocument) {
     return (
       <Empty className="min-h-screen">
         <EmptyHeader>
@@ -73,9 +76,11 @@ export function GuestPage({ pageId }: { pageId: string }) {
             theme={result.site.settings.theme}
           >
             <OpenEditorPageEditor
+              key={selectedPage._id}
               pageId={selectedPage._id}
               pages={result.pages}
               preview={selectedPage.guestPermission !== "editor"}
+              remoteDocument={selectedDocument}
               siteId={result.site._id}
             />
           </SiteThemeScope>

--- a/apps/web/features/openeditor/openeditor-page-editor.tsx
+++ b/apps/web/features/openeditor/openeditor-page-editor.tsx
@@ -12,7 +12,6 @@ import { api, type Doc, type Id } from "@baseblocks/backend";
 import { generateSlug } from "@baseblocks/domain";
 import type { SaveStatus } from "@baseblocks/domain";
 import { Button } from "@baseblocks/ui/button";
-import { Spinner } from "@baseblocks/ui/spinner";
 import type {
   OpenEditorAttachmentRuntime,
   OpenEditorDocument,
@@ -34,7 +33,7 @@ import {
   OpenEditorThemeProvider,
 } from "@openeditor/ui";
 import "@openeditor/ui/styles.css";
-import { useMutation, useQuery } from "convex/react";
+import { useMutation } from "convex/react";
 import { useEffect, useRef, type ReactNode } from "react";
 import { useTranslations } from "next-intl";
 import { toast } from "sonner";
@@ -44,6 +43,7 @@ import { useBaseBlocksImageRuntime } from "./image-runtime";
 import { baseBlocksOpenEditorTheme } from "./openeditor-theme";
 import { OpenEditorTabbedPage } from "./page-tabs";
 import { useVersionedPageDocument } from "./use-versioned-page-document";
+import type { VersionedDocument } from "./versioned-document";
 import {
   createOpenEditorPageTabs,
   deleteOpenEditorTextRange,
@@ -58,6 +58,7 @@ export function OpenEditorPageEditor({
   pageId,
   pages,
   preview = false,
+  remoteDocument,
   siteId,
 }: {
   authoritativeRefreshRevision?: number;
@@ -65,6 +66,7 @@ export function OpenEditorPageEditor({
   pageId: Id<"pages">;
   pages: Doc<"pages">[];
   preview?: boolean;
+  remoteDocument: VersionedDocument;
   siteId: Id<"sites">;
 }) {
   const t = useTranslations("editor.pageEditor");
@@ -76,16 +78,10 @@ export function OpenEditorPageEditor({
   const saveContent = useMutation(api.pageContent.save);
   const attachmentRuntime = useBaseBlocksAttachmentRuntime(siteId);
   const imageRuntime = useBaseBlocksImageRuntime(siteId);
-  const remoteDocument = useQuery(api.pageContent.getVersioned, { pageId });
   const { document, onChange } = useVersionedPageDocument({
     authoritativeRefreshRevision,
     pageId,
-    remote: remoteDocument
-      ? {
-          document: remoteDocument.document as OpenEditorDocument,
-          contentHash: remoteDocument.contentHash,
-        }
-      : remoteDocument,
+    remote: remoteDocument,
     save: saveContent,
     onSaveStatusChange,
     onError: () => toast.error(t("saveFailed")),
@@ -170,14 +166,6 @@ export function OpenEditorPageEditor({
       pageRuntime={pageRuntime}
     />
   ) : null;
-
-  if (!document) {
-    return (
-      <div className="flex min-h-[50vh] items-center justify-center text-muted-foreground">
-        <Spinner className="size-6" aria-label={t("loading")} />
-      </div>
-    );
-  }
 
   return (
     <SiteRenderActionsProvider actions={{ siteId }}>

--- a/apps/web/features/openeditor/use-versioned-page-document.test.tsx
+++ b/apps/web/features/openeditor/use-versioned-page-document.test.tsx
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import type { Id } from "@baseblocks/backend";
+import type { OpenEditorDocument } from "@openeditor/core";
+import { renderToStaticMarkup } from "react-dom/server";
+import { useVersionedPageDocument } from "./use-versioned-page-document";
+
+const remoteDocument = {
+  document: {
+    type: "doc",
+    content: [
+      {
+        type: "paragraph",
+        content: [{ type: "text", text: "Ready on first render" }],
+      },
+    ],
+  } as OpenEditorDocument,
+  contentHash: "sha256:test",
+};
+
+function InitialDocumentHarness() {
+  const { document } = useVersionedPageDocument({
+    onError: () => undefined,
+    pageId: "page-1" as Id<"pages">,
+    remote: remoteDocument,
+    save: async () => ({ ...remoteDocument, status: "saved" }),
+  });
+
+  return <output>{JSON.stringify(document)}</output>;
+}
+
+describe("versioned page document", () => {
+  test("renders the authoritative document without an effect-driven loading frame", () => {
+    expect(renderToStaticMarkup(<InitialDocumentHarness />)).toContain(
+      "Ready on first render",
+    );
+  });
+});

--- a/apps/web/features/openeditor/use-versioned-page-document.ts
+++ b/apps/web/features/openeditor/use-versioned-page-document.ts
@@ -9,11 +9,7 @@ import {
 import type { SaveStatus } from "@baseblocks/domain";
 import type { OpenEditorDocument } from "@openeditor/core";
 import { useCallback, useEffect, useRef, useState } from "react";
-
-type VersionedDocument = {
-  document: OpenEditorDocument;
-  contentHash: string;
-};
+import type { VersionedDocument } from "./versioned-document";
 
 type SaveResult = VersionedDocument & {
   status: "saved" | "conflict";
@@ -31,17 +27,17 @@ export function useVersionedPageDocument({
   onError: () => void;
   onSaveStatusChange?: (status: SaveStatus) => void;
   pageId: Id<"pages">;
-  remote: VersionedDocument | null | undefined;
+  remote: VersionedDocument;
   save: (args: {
     pageId: Id<"pages">;
     content: OpenEditorDocument;
     expectedContentHash: string;
   }) => Promise<SaveResult>;
 }) {
-  const [document, setDocument] = useState<OpenEditorDocument>();
-  const documentRef = useRef<OpenEditorDocument | undefined>(undefined);
-  const baseHashRef = useRef<string | undefined>(undefined);
-  const baseDocumentRef = useRef<OpenEditorDocument | undefined>(undefined);
+  const [document, setDocument] = useState<OpenEditorDocument>(remote.document);
+  const documentRef = useRef<OpenEditorDocument>(remote.document);
+  const baseHashRef = useRef<string>(remote.contentHash);
+  const baseDocumentRef = useRef<OpenEditorDocument>(remote.document);
   const pendingRef = useRef<OpenEditorDocument | undefined>(undefined);
   const inFlightDocumentRef = useRef<OpenEditorDocument | undefined>(undefined);
   const savingRef = useRef(false);
@@ -64,13 +60,12 @@ export function useVersionedPageDocument({
   }, []);
 
   const persist = useCallback(async () => {
-    if (savingRef.current || !baseHashRef.current) return;
+    if (savingRef.current) return;
     const writeGeneration = writeGenerationRef.current;
     savingRef.current = true;
     while (
       writeGeneration === writeGenerationRef.current &&
-      pendingRef.current &&
-      baseHashRef.current
+      pendingRef.current
     ) {
       const submitted = pendingRef.current;
       if (!submitted) break;
@@ -102,10 +97,7 @@ export function useVersionedPageDocument({
 
       if (result.status === "conflict") {
         const baseDocument = baseDocumentRef.current;
-        if (
-          baseDocument &&
-          !hasSameNonPageContent(baseDocument, result.document)
-        ) {
+        if (!hasSameNonPageContent(baseDocument, result.document)) {
           conflictRef.current = true;
           baseHashRef.current = result.contentHash;
           baseDocumentRef.current = result.document;
@@ -117,7 +109,7 @@ export function useVersionedPageDocument({
         }
         baseHashRef.current = result.contentHash;
         baseDocumentRef.current = result.document;
-        const local = documentRef.current ?? submitted;
+        const local = documentRef.current;
         const rebased = reconcileChildPageProjection(local, result.document);
         apply(rebased);
         if (JSON.stringify(rebased) !== JSON.stringify(result.document)) {
@@ -127,14 +119,13 @@ export function useVersionedPageDocument({
       }
 
       if (baseHashRef.current !== expectedContentHash) {
-        const current = documentRef.current;
-        if (current) pendingRef.current = current;
+        pendingRef.current = documentRef.current;
         continue;
       }
       baseHashRef.current = result.contentHash;
       baseDocumentRef.current = result.document;
       const current = documentRef.current;
-      if (!current || JSON.stringify(current) === JSON.stringify(submitted)) {
+      if (JSON.stringify(current) === JSON.stringify(submitted)) {
         apply(result.document);
       } else {
         pendingRef.current = current;
@@ -175,19 +166,12 @@ export function useVersionedPageDocument({
   );
 
   useEffect(() => {
-    if (!remote) return;
-    const incoming = remote.document as OpenEditorDocument;
+    const incoming = remote.document;
     if (conflictRef.current) return;
-    if (!baseHashRef.current) {
-      baseHashRef.current = remote.contentHash;
-      baseDocumentRef.current = incoming;
-      apply(incoming);
-      return;
-    }
     if (remote.contentHash === baseHashRef.current) return;
 
     const local = documentRef.current;
-    if (!local || (!pendingRef.current && !savingRef.current)) {
+    if (!pendingRef.current && !savingRef.current) {
       baseHashRef.current = remote.contentHash;
       baseDocumentRef.current = incoming;
       apply(incoming);
@@ -198,7 +182,6 @@ export function useVersionedPageDocument({
     const baseDocument = baseDocumentRef.current;
     const inFlightDocument = inFlightDocumentRef.current;
     if (
-      baseDocument &&
       !hasSameNonPageContent(baseDocument, incoming) &&
       (!inFlightDocument || !hasSameNonPageContent(inFlightDocument, incoming))
     ) {
@@ -240,9 +223,7 @@ export function useVersionedPageDocument({
       }
       pendingRef.current = next;
       onSaveStatusChangeRef.current?.("pending");
-      schedule(
-        previous && !hasSameChildPageProjection(previous, next) ? 0 : 750,
-      );
+      schedule(!hasSameChildPageProjection(previous, next) ? 0 : 750);
     },
     [apply, schedule],
   );

--- a/apps/web/features/openeditor/versioned-document.ts
+++ b/apps/web/features/openeditor/versioned-document.ts
@@ -1,0 +1,6 @@
+import type { OpenEditorDocument } from "@openeditor/core";
+
+export interface VersionedDocument {
+  document: OpenEditorDocument;
+  contentHash: string;
+}

--- a/apps/web/lib/convex/provider.tsx
+++ b/apps/web/lib/convex/provider.tsx
@@ -9,11 +9,18 @@ import type { ReactNode } from "react";
 import { authClient } from "@/lib/auth/client";
 import { convex } from "@/lib/convex/client";
 
-export function ConvexClientProvider({ children }: { children: ReactNode }) {
+export function ConvexClientProvider({
+  children,
+  initialToken,
+}: {
+  children: ReactNode;
+  initialToken?: string | null;
+}) {
   return (
     <ConvexBetterAuthProvider
       authClient={authClient as unknown as AuthClient}
       client={convex}
+      initialToken={initialToken}
     >
       {children}
     </ConvexBetterAuthProvider>

--- a/docs/research/editor-reactive-loading-architecture.md
+++ b/docs/research/editor-reactive-loading-architecture.md
@@ -1,0 +1,132 @@
+# Production architecture for reactive editor loading
+
+Research date: 2026-08-12. Sources are current official React, Next.js,
+Convex, and Convex Better Auth documentation.
+
+## Conclusion
+
+The server-to-client authentication fix is the documented architecture, and
+the coordinated client readiness check is correct. The remaining structural
+simplification is to make the backend API match the UI's actual consistency
+boundary: the site, pages, selected page document, restore state, and release
+summary form one **editor snapshot** and should be returned by one authenticated
+reactive Convex query.
+
+The production shape should be:
+
+1. The authenticated Next.js layout obtains the token on the server and gives
+   it to `ConvexBetterAuthProvider` as `initialToken`.
+2. One reactive `getEditorSnapshot({ organizationId, siteId, pageId })` query
+   returns a discriminated result such as `missing | restoring | ready` and,
+   when ready, all data required for the first editor paint.
+3. The client derives loading directly from the query's `undefined` result and
+   does not mount the themed editor surface until the complete snapshot exists.
+4. The editable session is mounted beneath a `key` based on selected page
+   identity. Its initial document state is initialized synchronously from the
+   snapshot; Effects are reserved for synchronization with external systems.
+
+This is simpler than coordinating several feature-level queries and makes the
+backend transaction, client readiness state, and intended visual reveal the
+same boundary.
+
+Authenticated server preloading can later eliminate the initial client query
+wait while retaining reactivity. It is an optimization, not required for
+correctness, and Convex currently labels its general Next.js server-rendering
+support beta. The cohesive reactive query and explicit readiness boundary are
+therefore the stable foundation.
+
+## Evidence and decisions
+
+### Pass the initial auth token from the server
+
+Convex Better Auth's official Next.js setup exports `getToken` from its server
+utilities and shows passing that value to `ConvexBetterAuthProvider` through
+its `initialToken` prop. This is the supported way to avoid beginning client
+subscriptions in a temporarily unauthenticated state. Next.js explicitly
+supports passing serializable values from Server Components to Client
+Components and recommends rendering providers as deep as practical.
+
+- [Convex Better Auth: Next.js](https://labs.convex.dev/better-auth/framework-guides/next)
+- [Next.js: Server and Client Components](https://nextjs.org/docs/app/getting-started/server-and-client-components)
+
+The token handoff speeds authentication establishment; authorization must
+still be enforced in every Convex query and mutation.
+
+### Combine queries when the result is one domain view
+
+Convex guarantees that all database reads inside one query occur at the same
+logical timestamp. Its React client also guarantees that separate live query
+subscriptions are updated together to a consistent database snapshot. Separate
+`useQuery` hooks are therefore not inherently unsafe.
+
+However, `useQueries` is documented primarily for a dynamic number of queries,
+not as an atomic-reveal abstraction. When the UI always needs a fixed set of
+values together, one aggregate query removes intermediate result combinations,
+duplicates fewer permission/site reads, and gives the backend a cohesive DTO.
+For this editor, the selected document and draft summary belong in the existing
+workspace query rather than in sibling feature queries.
+
+- [Convex: query caching, reactivity, and consistency](https://docs.convex.dev/functions/query-functions#caching--reactivity--consistency)
+- [Convex React: consistency and reactive queries](https://docs.convex.dev/client/react/overview#consistency)
+- [Convex React API: `useQueries`](https://docs.convex.dev/api/modules/react#usequeries)
+
+If server preloading is introduced, the case for aggregation is stronger:
+Convex documents that multiple `preloadQuery` calls use stateless HTTP clients
+and are not guaranteed to observe one database state. One preloaded aggregate
+query avoids that inconsistency.
+
+- [Convex: Next.js server rendering](https://docs.convex.dev/client/nextjs/app-router/server-rendering#consistency)
+
+### Make loading an explicit, atomic reveal boundary
+
+`useQuery` returns `undefined` during its initial load and then maintains a live
+subscription. The editor should translate that one pending value into its one
+shell loading state and reveal the themed canvas only for a complete `ready`
+snapshot. A missing query result must remain distinct from a pending result.
+
+React Suspense can coordinate a reveal only when children actually suspend.
+React explicitly says that fetching in Effects is not detected by Suspense;
+ordinary Convex `useQuery` is likewise not a Suspense data source. Wrapping the
+current hooks in arbitrary Suspense boundaries would not simplify the state
+model. If authenticated server preloading is adopted, use the integration's
+documented `preloadAuthQuery` and `usePreloadedAuthQuery` pair, which provides
+the server result initially and retains a reactive client subscription.
+
+- [Convex React API: `useQuery`](https://docs.convex.dev/api/modules/react#usequery)
+- [React: Suspense and supported data sources](https://react.dev/reference/react/Suspense#what-activates-a-suspense-boundary)
+- [Convex Better Auth: SSR with Server Components](https://labs.convex.dev/better-auth/framework-guides/next#ssr-with-server-components)
+
+### Do not derive the editable document through an Effect
+
+React says that data computable from current props or state should be derived
+during render, not copied in an Effect. An Effect-driven reset first commits
+stale state, then causes a second render. For conceptually different entities,
+React recommends keying the stateful subtree so the state is reset as part of
+rendering.
+
+The editor should therefore initialize its local editable document
+synchronously from the ready snapshot and key the editor session by page ID.
+That guarantees a page switch cannot briefly render the previous page's local
+draft. Remote updates to the same page are a genuine synchronization/conflict
+problem and may use Effects or subscription logic; they should not be confused
+with initial-state derivation or page-identity reset.
+
+- [React: You Might Not Need an Effect](https://react.dev/learn/you-might-not-need-an-effect)
+- [React: Preserving and Resetting State](https://react.dev/learn/preserving-and-resetting-state#option-2-resetting-state-with-a-key)
+
+## Production-readiness checklist
+
+- Keep exactly one shared `ConvexReactClient` across client-side navigation.
+- Keep server token handoff in the deepest authenticated provider shared by the
+  editor routes.
+- Return one validated editor snapshot DTO and authorize it at the data source.
+- Represent pending, missing/unauthorized, restoring, and ready explicitly;
+  never interpret `undefined` as missing.
+- Mount no themed canvas until `ready` contains the selected page document and
+  every value required for its first paint.
+- Key the stateful editor session by page identity and initialize its document
+  synchronously.
+- Preserve Convex subscriptions for post-mount updates; do not replace reactive
+  reads with one-off server fetches.
+- Treat authenticated preloading as an optional measured optimization and use
+  a single aggregate preload if adopted.

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -41,6 +41,7 @@ import type * as model_billingRetention from "../model/billingRetention.js";
 import type * as model_contentObjects from "../model/contentObjects.js";
 import type * as model_draft from "../model/draft.js";
 import type * as model_draftChanges from "../model/draftChanges.js";
+import type * as model_draftSummary from "../model/draftSummary.js";
 import type * as model_fileExtraction from "../model/fileExtraction.js";
 import type * as model_libraryAccess from "../model/libraryAccess.js";
 import type * as model_pageDeletion from "../model/pageDeletion.js";
@@ -124,6 +125,7 @@ declare const fullApi: ApiFromModules<{
   "model/contentObjects": typeof model_contentObjects;
   "model/draft": typeof model_draft;
   "model/draftChanges": typeof model_draftChanges;
+  "model/draftSummary": typeof model_draftSummary;
   "model/fileExtraction": typeof model_fileExtraction;
   "model/libraryAccess": typeof model_libraryAccess;
   "model/pageDeletion": typeof model_pageDeletion;

--- a/packages/backend/convex/editorWorkspace.ts
+++ b/packages/backend/convex/editorWorkspace.ts
@@ -2,6 +2,9 @@ import { v } from "convex/values";
 import { query } from "./_generated/server";
 import { isOrganizationMember } from "./permissions";
 import type { Doc, Id } from "./_generated/dataModel";
+import { buildDraftSummary } from "./model/draftSummary";
+import { readPageContent } from "./model/pageDocuments";
+import { hashOpenEditorContent } from "./pageContentFormat";
 
 export function draftRestoreView(
   restoreId: Id<"draftRestores">,
@@ -27,17 +30,27 @@ export function draftRestoreView(
  * loading (and briefly disagreeing about) the same site and page collection.
  */
 export const get = query({
-  args: { organizationId: v.string(), siteId: v.id("sites") },
-  handler: async (ctx, { organizationId, siteId }) => {
+  args: {
+    organizationId: v.string(),
+    siteId: v.id("sites"),
+    requestedPageId: v.optional(v.string()),
+  },
+  handler: async (ctx, { organizationId, siteId, requestedPageId }) => {
     const site = await ctx.db.get(siteId);
     if (!site || site.organizationId !== organizationId) return null;
     if (!(await isOrganizationMember(ctx, site.organizationId))) return null;
 
+    const draftSummary = await buildDraftSummary(ctx, site);
+
     if (site.activeDraftRestoreId) {
       const restore = await ctx.db.get(site.activeDraftRestoreId);
       return {
+        status: "restoring" as const,
         site,
         pages: [],
+        selectedPage: null,
+        selectedDocument: null,
+        draftSummary,
         restore: draftRestoreView(site.activeDraftRestoreId, restore),
       };
     }
@@ -47,9 +60,34 @@ export const get = query({
       .withIndex("by_site", (q) => q.eq("siteId", siteId))
       .collect();
 
+    const visiblePages = pages.filter((page) => page.deletedAt === undefined);
+    const normalizedRequestedPageId = requestedPageId
+      ? ctx.db.normalizeId("pages", requestedPageId)
+      : null;
+    const selectedPage =
+      visiblePages.find((page) => page._id === normalizedRequestedPageId) ??
+      visiblePages[0] ??
+      null;
+    const selectedContent = selectedPage
+      ? await readPageContent(ctx, selectedPage._id)
+      : null;
+
     return {
+      status: "ready" as const,
       site,
-      pages: pages.filter((page) => page.deletedAt === undefined),
+      pages: visiblePages,
+      selectedPage,
+      selectedDocument:
+        selectedPage && selectedContent
+          ? {
+              pageId: selectedPage._id,
+              document: selectedContent.document,
+              contentHash:
+                selectedContent.record?.contentHash ??
+                hashOpenEditorContent(JSON.stringify(selectedContent.document)),
+            }
+          : null,
+      draftSummary,
       restore: null,
     };
   },

--- a/packages/backend/convex/model/draftSummary.ts
+++ b/packages/backend/convex/model/draftSummary.ts
@@ -1,0 +1,25 @@
+import type { Doc } from "../_generated/dataModel";
+import type { QueryCtx } from "../_generated/server";
+
+export async function buildDraftSummary(ctx: QueryCtx, site: Doc<"sites">) {
+  const liveRelease = site.liveReleaseId
+    ? await ctx.db.get(site.liveReleaseId)
+    : null;
+  const hasDraftChanges =
+    (await ctx.db
+      .query("draftChanges")
+      .withIndex("by_site", (q) => q.eq("siteId", site._id))
+      .first()) !== null;
+
+  return {
+    draftRevision: site.draftRevision,
+    liveRelease: liveRelease
+      ? { _id: liveRelease._id, number: liveRelease.number }
+      : null,
+    nextReleaseNumber: site.nextReleaseNumber,
+    hasUnpublishedChanges:
+      Boolean(site.activeDraftRestoreId) ||
+      hasDraftChanges ||
+      site.draftBaseReleaseId !== site.liveReleaseId,
+  };
+}

--- a/packages/backend/convex/releases.ts
+++ b/packages/backend/convex/releases.ts
@@ -12,6 +12,7 @@ import {
   extractionBlocksPublication,
   isPublicationInFlight,
 } from "./model/releaseState";
+import { buildDraftSummary } from "./model/draftSummary";
 import {
   findActivePublication,
   promoteRelease,
@@ -56,23 +57,7 @@ export const getDraftSummary = query({
   handler: async (ctx, { siteId }) => {
     const site = await requireSiteForMember(ctx, siteId);
     if (!site) return null;
-    const liveRelease = site.liveReleaseId
-      ? await ctx.db.get(site.liveReleaseId)
-      : null;
-    return {
-      draftRevision: site.draftRevision,
-      liveRelease: liveRelease
-        ? { _id: liveRelease._id, number: liveRelease.number }
-        : null,
-      nextReleaseNumber: site.nextReleaseNumber,
-      hasUnpublishedChanges:
-        Boolean(site.activeDraftRestoreId) ||
-        (await ctx.db
-          .query("draftChanges")
-          .withIndex("by_site", (q) => q.eq("siteId", siteId))
-          .first()) !== null ||
-        site.draftBaseReleaseId !== site.liveReleaseId,
-    };
+    return buildDraftSummary(ctx, site);
   },
 });
 


### PR DESCRIPTION
## Summary
- seed Convex authentication from the server token so editor subscriptions never begin anonymously
- replace separate workspace, document, and release reads with one authenticated reactive editor snapshot
- keep the themed canvas unmounted until its complete document is ready and initialize editor state synchronously
- key guest and main editor sessions by page identity
- add reveal-boundary and first-render regression coverage

## Verification
- bun run lint
- bun run check-types
- bun test (200 passing)
- production Next.js build
- browser reload timeline: shell-loading -> document-ready, with no themed-empty or site-not-found state

## Research
Primary-source architecture review is included at docs/research/editor-reactive-loading-architecture.md.