### PR TITLE
Eliminate billing webhook retry amplification

### DIFF
--- a/packages/backend/convex/billingDeletion.test.ts
+++ b/packages/backend/convex/billingDeletion.test.ts
@@ -89,4 +89,82 @@ describe("workspace billing deletion", () => {
       }),
     );
   });
+
+  test("ignores unsupported events before looking up workspace metadata", async () => {
+    const patches: Array<Record<string, unknown>> = [];
+    let organizationLookups = 0;
+    const event = {
+      _id: "event-unsupported",
+      status: "failed",
+      attemptCount: 74,
+      eventType: "checkout.created",
+      organizationId: "checkout-contract-probe",
+      payload: { data: { id: "checkout-1" } },
+    };
+    await (processWebhook as unknown as RegisteredFunction)._handler(
+      {
+        db: {
+          get: async () => event,
+          patch: async (_id: string, value: Record<string, unknown>) => {
+            patches.push(value);
+          },
+        },
+        runQuery: async () => {
+          organizationLookups += 1;
+          throw new Error("Unsupported events must not query organizations");
+        },
+      },
+      { eventId: "event-unsupported" },
+    );
+
+    expect(organizationLookups).toBe(0);
+    expect(patches).toContainEqual(
+      expect.objectContaining({
+        status: "ignored",
+        failureCode: "EVENT_NOT_APPLICABLE",
+        attemptCount: 75,
+      }),
+    );
+  });
+
+  test("dead-letters a permanent failure after a bounded number of attempts", async () => {
+    const patches: Array<Record<string, unknown>> = [];
+    let scheduledRetries = 0;
+    const event = {
+      _id: "event-poison",
+      status: "failed",
+      attemptCount: 7,
+      eventType: "subscription.updated",
+      organizationId: "organization-invalid",
+      payload: { data: { id: "subscription-1" } },
+    };
+    await (processWebhook as unknown as RegisteredFunction)._handler(
+      {
+        db: {
+          get: async () => event,
+          patch: async (_id: string, value: Record<string, unknown>) => {
+            patches.push(value);
+          },
+        },
+        runQuery: async () => {
+          throw new Error("Permanent organization lookup failure");
+        },
+        scheduler: {
+          runAfter: async () => {
+            scheduledRetries += 1;
+          },
+        },
+      },
+      { eventId: "event-poison" },
+    );
+
+    expect(scheduledRetries).toBe(0);
+    expect(patches).toContainEqual(
+      expect.objectContaining({
+        status: "deadLettered",
+        attemptCount: 8,
+        nextAttemptAt: undefined,
+      }),
+    );
+  });
 });

--- a/packages/backend/convex/billingModel.ts
+++ b/packages/backend/convex/billingModel.ts
@@ -31,6 +31,9 @@ import {
 } from "./billing/polar";
 
 type JsonObject = Record<string, unknown>;
+type WebhookKind = "subscription" | "order";
+
+const MAX_WEBHOOK_ATTEMPTS = 8;
 
 function object(value: unknown): JsonObject | null {
   return value && typeof value === "object" && !Array.isArray(value)
@@ -62,6 +65,12 @@ function findWorkspaceId(data: JsonObject): string | undefined {
     string(data.external_customer_id) ??
     string(customer?.external_id)
   );
+}
+
+function webhookKind(eventType: string): WebhookKind | null {
+  if (eventType.startsWith("subscription.")) return "subscription";
+  if (eventType.startsWith("order.")) return "order";
+  return null;
 }
 
 function normalizedOrderState(eventType: string, data: JsonObject) {
@@ -991,24 +1000,35 @@ export const processWebhook = internalMutation({
   args: { eventId: v.id("billingWebhookEvents") },
   handler: async (ctx, { eventId }) => {
     const event = await ctx.db.get(eventId);
-    if (!event || event.status === "processed" || event.status === "ignored") {
-      return null;
-    }
-    const now = Date.now();
     if (
-      event.status === "processing" &&
-      event.leaseExpiresAt !== undefined &&
-      event.leaseExpiresAt > now
+      !event ||
+      event.status === "processed" ||
+      event.status === "ignored" ||
+      event.status === "deadLettered"
     ) {
       return null;
     }
-    await ctx.db.patch(event._id, {
-      status: "processing",
-      attemptCount: event.attemptCount + 1,
-      leaseExpiresAt: now + 60_000,
-      nextAttemptAt: now + 60_000,
-      updatedAt: now,
-    });
+    const now = Date.now();
+    const kind = webhookKind(event.eventType);
+    if (!kind) {
+      await ctx.db.patch(event._id, {
+        status: "ignored",
+        attemptCount: event.attemptCount + 1,
+        failureCode: "EVENT_NOT_APPLICABLE",
+        failureMessage: undefined,
+        processedAt: now,
+        nextAttemptAt: undefined,
+        updatedAt: now,
+      });
+      return null;
+    }
+    if (
+      event.status === "failed" &&
+      event.nextAttemptAt !== undefined &&
+      event.nextAttemptAt > now
+    ) {
+      return null;
+    }
     try {
       const payload = object(event.payload);
       const data = object(payload?.data);
@@ -1017,9 +1037,10 @@ export const processWebhook = internalMutation({
       if (!organizationId) {
         await ctx.db.patch(event._id, {
           status: "ignored",
+          attemptCount: event.attemptCount + 1,
           failureCode: "WORKSPACE_ID_MISSING",
           processedAt: now,
-          leaseExpiresAt: undefined,
+          nextAttemptAt: undefined,
           updatedAt: now,
         });
         return null;
@@ -1035,47 +1056,40 @@ export const processWebhook = internalMutation({
         await ctx.db.patch(event._id, {
           status: "ignored",
           organizationId,
+          attemptCount: event.attemptCount + 1,
           failureCode: "WORKSPACE_DELETED",
           processedAt: now,
-          leaseExpiresAt: undefined,
           nextAttemptAt: undefined,
           updatedAt: now,
         });
         return null;
       }
-      if (event.eventType.startsWith("subscription.")) {
+      if (kind === "subscription") {
         await upsertSubscription(ctx, event, data, organizationId);
-      } else if (event.eventType.startsWith("order.")) {
-        await processOrder(ctx, event, data, organizationId);
       } else {
-        await ctx.db.patch(event._id, {
-          status: "ignored",
-          failureCode: "EVENT_NOT_APPLICABLE",
-          processedAt: now,
-          leaseExpiresAt: undefined,
-          updatedAt: now,
-        });
-        return null;
+        await processOrder(ctx, event, data, organizationId);
       }
       await ctx.db.patch(event._id, {
         status: "processed",
         organizationId,
+        attemptCount: event.attemptCount + 1,
         processedAt: Date.now(),
-        leaseExpiresAt: undefined,
         nextAttemptAt: undefined,
         failureCode: undefined,
         failureMessage: undefined,
         updatedAt: Date.now(),
       });
     } catch (error) {
+      const attemptCount = event.attemptCount + 1;
       const retryDelay = Math.min(
         60 * 60_000,
         60_000 * 2 ** Math.min(event.attemptCount, 6),
       );
+      const terminal = attemptCount >= MAX_WEBHOOK_ATTEMPTS;
       await ctx.db.patch(event._id, {
-        status: "failed",
-        leaseExpiresAt: undefined,
-        nextAttemptAt: Date.now() + retryDelay,
+        status: terminal ? "deadLettered" : "failed",
+        attemptCount,
+        nextAttemptAt: terminal ? undefined : Date.now() + retryDelay,
         failureCode: "PROCESSING_FAILED",
         failureMessage:
           error instanceof Error
@@ -1083,39 +1097,14 @@ export const processWebhook = internalMutation({
             : "Unknown error",
         updatedAt: Date.now(),
       });
-      await ctx.scheduler.runAfter(
-        retryDelay,
-        internal.billingModel.processWebhook,
-        { eventId: event._id },
-      );
+      if (!terminal) {
+        await ctx.scheduler.runAfter(
+          retryDelay,
+          internal.billingModel.processWebhook,
+          { eventId: event._id },
+        );
+      }
     }
     return null;
-  },
-});
-
-export const recoverWebhookEvents = internalMutation({
-  args: {},
-  handler: async (ctx) => {
-    const now = Date.now();
-    const [failed, stalled] = await Promise.all([
-      ctx.db
-        .query("billingWebhookEvents")
-        .withIndex("by_status_retry", (q) =>
-          q.eq("status", "failed").lte("nextAttemptAt", now),
-        )
-        .take(50),
-      ctx.db
-        .query("billingWebhookEvents")
-        .withIndex("by_status_retry", (q) =>
-          q.eq("status", "processing").lte("nextAttemptAt", now),
-        )
-        .take(50),
-    ]);
-    for (const event of [...failed, ...stalled]) {
-      await ctx.scheduler.runAfter(0, internal.billingModel.processWebhook, {
-        eventId: event._id,
-      });
-    }
-    return failed.length + stalled.length;
   },
 });

--- a/packages/backend/convex/crons.test.ts
+++ b/packages/backend/convex/crons.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, test } from "bun:test";
+import crons from "./crons";
+
+describe("scheduled maintenance", () => {
+  test("does not poll the durable webhook queue", () => {
+    expect(Object.keys(crons.crons)).not.toContain(
+      "repair Polar webhook processing",
+    );
+  });
+});

--- a/packages/backend/convex/crons.ts
+++ b/packages/backend/convex/crons.ts
@@ -10,12 +10,6 @@ crons.interval(
 );
 
 crons.interval(
-  "repair Polar webhook processing",
-  { minutes: 15 },
-  internal.billingModel.recoverWebhookEvents,
-);
-
-crons.interval(
   "expire included AI credits",
   { minutes: 15 },
   internal.aiCredits.expireDueIncludedLots,

--- a/packages/backend/convex/schema/billing.ts
+++ b/packages/backend/convex/schema/billing.ts
@@ -273,13 +273,12 @@ export const billingTables = {
     payload: v.any(),
     status: v.union(
       v.literal("pending"),
-      v.literal("processing"),
       v.literal("processed"),
       v.literal("ignored"),
       v.literal("failed"),
+      v.literal("deadLettered"),
     ),
     attemptCount: v.number(),
-    leaseExpiresAt: v.optional(v.number()),
     nextAttemptAt: v.optional(v.number()),
     failureCode: v.optional(v.string()),
     failureMessage: v.optional(v.string()),
@@ -288,7 +287,6 @@ export const billingTables = {
     updatedAt: v.number(),
   })
     .index("by_environment_delivery", ["providerEnvironment", "deliveryId"])
-    .index("by_status_retry", ["status", "nextAttemptAt"])
     .index("by_resource_occurred", [
       "resourceType",
       "resourceId",


### PR DESCRIPTION
## What changed

- Remove the 15-minute global webhook recovery poll and its retry index.
- Reject unsupported Polar events before workspace lookups.
- Bound applicable-event retries at eight attempts with a terminal dead-letter state.
- Remove the redundant processing lease state.
- Add regression tests for empty-queue polling, unsupported events, and bounded poison-event retries.

## Root cause

A `checkout.created` event with invalid workspace metadata entered the general processor before unsupported event types were rejected. It failed 76 times. Each failure scheduled a retry, while the recovery cron also scheduled the same event. Every dev, preview, and production deployment also scanned the retry index every 15 minutes when the queue was empty.

## Impact

Idle billing webhook recovery now performs zero database reads and zero function calls. Unsupported events become terminal without organization I/O. Permanent applicable failures stop after eight attempts instead of retrying forever.

## Migration and verification

- Deployed to development and removed `billingWebhookEvents.by_status_retry`.
- Migrated the poison event to `ignored / EVENT_NOT_APPLICABLE`.
- Verified development has zero pending, failed, or dead-lettered webhook events.
- Verified the branch Convex preview `aromatic-donkey-867` has no recovery function, no recovery cron, and no health insights.
- `bun test`: 203 passed.
- `bun run check-types`: all workspace type checks passed.
- Vercel preview deployment passed.

Production will receive the schema and function migration when this pull request merges.