### PR TITLE
Fix team role badge hierarchy

### DIFF
--- a/apps/web/features/dashboard/team/team-page.tsx
+++ b/apps/web/features/dashboard/team/team-page.tsx
@@ -65,11 +65,11 @@ export function TeamPage() {
     return "?";
   };
 
-  const getRoleBadgeVariant = (role: string) => {
-    if (role === "owner") return "secondary";
+  const getRoleBadgeVariant = (role: OrganizationRole) => {
+    if (role === "owner") return "default";
     if (role === "admin") return "secondary";
-    if (role === "editor") return "default";
-    return "outline";
+    if (role === "editor") return "outline";
+    return "ghost";
   };
 
   if (!team) {


### PR DESCRIPTION
## What changed

- Give the Owner badge the primary style.
- Keep Admin on the secondary style.
- Use the outline style for Editor.
- Use the quiet ghost style for Viewer.
- Type the role-style helper with `OrganizationRole`.

## Why

The previous mapping made Editor more noticeable than Owner and gave Owner and Admin the same visual treatment. The new mapping matches the permission hierarchy and reuses the existing badge variants.

## Validation

- `./node_modules/.bin/biome check apps/web/features/dashboard/team/team-page.tsx`
- `bun run check-types --filter=@baseblocks/web`
- Verified the Owner badge on the local Team page in the Codex browser.