### PR TITLE
Redesign site settings dialog

### DIFF
--- a/apps/web/components/file-viewer/file-ui.tsx
+++ b/apps/web/components/file-viewer/file-ui.tsx
@@ -30,7 +30,9 @@ export function DropZone({
   children,
   className,
   disabled = false,
+  inputAriaLabel,
   maxSize = defaultMaxSize,
+  multiple = true,
   noClick = false,
   onFilesAccepted,
 }: {
@@ -38,7 +40,9 @@ export function DropZone({
   children?: React.ReactNode;
   className?: string;
   disabled?: boolean;
+  inputAriaLabel?: string;
   maxSize?: number;
+  multiple?: boolean;
   noClick?: boolean;
   onFilesAccepted: (files: File[]) => void;
 }) {
@@ -47,7 +51,7 @@ export function DropZone({
       accept,
       disabled,
       maxSize,
-      multiple: true,
+      multiple,
       noClick,
       useFsAccessApi: false,
       onDrop: (acceptedFiles) => {
@@ -71,7 +75,7 @@ export function DropZone({
         className,
       )}
     >
-      <input {...getInputProps()} />
+      <input {...getInputProps({ "aria-label": inputAriaLabel })} />
       {children || (
         <div className="flex flex-col items-center justify-center px-4 py-8">
           <div

--- a/apps/web/features/editor/settings/custom-brand-color.tsx
+++ b/apps/web/features/editor/settings/custom-brand-color.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import {
+  DEFAULT_CUSTOM_BRAND_COLOR,
+  isValidBrandColor,
+  normalizeBrandColor,
+} from "@baseblocks/domain";
+import { Button } from "@baseblocks/ui/button";
+import { ColorPicker } from "@baseblocks/ui/color-picker";
+import { Label } from "@baseblocks/ui/label";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@baseblocks/ui/popover";
+import { Spinner } from "@baseblocks/ui/spinner";
+
+export function CustomBrandColor({
+  color,
+  disabled,
+  inputId,
+  onApply,
+  onColorChange,
+  onOpenChange,
+  open,
+}: {
+  color: string;
+  disabled: boolean;
+  inputId: string;
+  onApply: () => void;
+  onColorChange: (color: string) => void;
+  onOpenChange: (open: boolean) => void;
+  open: boolean;
+}) {
+  const normalizedColor =
+    normalizeBrandColor(color) ?? DEFAULT_CUSTOM_BRAND_COLOR;
+
+  return (
+    <div className="space-y-2 sm:col-span-2">
+      <Label htmlFor={inputId}>Custom brand color</Label>
+      <Popover onOpenChange={onOpenChange} open={open}>
+        <PopoverTrigger asChild>
+          <Button
+            className="h-10 w-full justify-start px-3 font-normal"
+            disabled={disabled}
+            id={inputId}
+            type="button"
+            variant="outline"
+          >
+            <span
+              aria-hidden
+              className="size-5 rounded-md border border-black/10 shadow-xs dark:border-white/15"
+              style={{ backgroundColor: normalizedColor }}
+            />
+            <span className="font-mono text-xs uppercase">
+              {normalizedColor}
+            </span>
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent align="start" className="w-72 space-y-3 p-3">
+          <ColorPicker
+            disabled={disabled}
+            onValueChange={onColorChange}
+            value={normalizedColor}
+          />
+          <div className="flex justify-end gap-2 border-t pt-3">
+            <Button
+              disabled={disabled}
+              onClick={() => onOpenChange(false)}
+              size="sm"
+              type="button"
+              variant="ghost"
+            >
+              Cancel
+            </Button>
+            <Button
+              disabled={disabled || !isValidBrandColor(color)}
+              onClick={onApply}
+              size="sm"
+              type="button"
+            >
+              {disabled ? <Spinner /> : null}
+              Apply
+            </Button>
+          </div>
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}

--- a/apps/web/features/editor/settings/favicon-settings.tsx
+++ b/apps/web/features/editor/settings/favicon-settings.tsx
@@ -1,18 +1,10 @@
 "use client";
 
-import { HugeiconsIcon } from "@hugeicons/react";
-import {
-  Delete01Icon,
-  Image01Icon,
-  Upload01Icon,
-} from "@hugeicons/core-free-icons";
 import { useImageUpload } from "@/lib/files/use-image-upload";
 import type { Id } from "@baseblocks/backend";
-import { Button } from "@baseblocks/ui/button";
-import { Spinner } from "@baseblocks/ui/spinner";
-import Image from "next/image";
-import { useRef } from "react";
+import { useState } from "react";
 import { toast } from "sonner";
+import { ImageAssetDropZone } from "./image-asset-dropzone";
 
 export function FaviconSettings({
   favicon,
@@ -23,19 +15,21 @@ export function FaviconSettings({
   onChange: (favicon?: string) => Promise<void>;
   siteId: Id<"sites">;
 }) {
-  const inputRef = useRef<HTMLInputElement>(null);
   const { uploadImage, uploadState } = useImageUpload();
+  const [isRemoving, setIsRemoving] = useState(false);
 
   const upload = async (file?: File) => {
     if (!file) return;
     if (!file.type.startsWith("image/")) {
-      toast.error("Please select an image file");
+      toast.error("Select an image file.");
       return;
     }
 
     const result = await uploadImage(file, siteId).catch(() => null);
     if (!result) {
-      toast.error(uploadState.error ?? "Upload failed");
+      toast.error(
+        uploadState.error ?? "Unable to upload the favicon. Try again.",
+      );
       return;
     }
 
@@ -43,60 +37,28 @@ export function FaviconSettings({
     toast.success("Favicon updated");
   };
 
+  const remove = async () => {
+    if (isRemoving) return;
+    setIsRemoving(true);
+    try {
+      await onChange(undefined);
+      toast.success("Favicon removed");
+    } catch {
+      toast.error("Unable to remove the favicon. Try again.");
+    } finally {
+      setIsRemoving(false);
+    }
+  };
+
   return (
-    <div className="flex min-w-0 flex-wrap items-center gap-2">
-      <input
-        ref={inputRef}
-        type="file"
-        accept=".ico,.png,.jpg,.jpeg,.webp,.svg,image/*"
-        className="hidden"
-        onChange={(event) => {
-          void upload(event.target.files?.[0]);
-          event.target.value = "";
-        }}
-      />
-      {favicon ? (
-        <div className="flex size-8 items-center justify-center rounded-md border border-border/70 bg-background p-1">
-          <Image
-            src={favicon}
-            alt="Favicon preview"
-            className="size-full object-contain"
-            width={24}
-            height={24}
-            unoptimized
-          />
-        </div>
-      ) : (
-        <div className="flex size-8 items-center justify-center rounded-md border border-dashed border-border/70 bg-muted/20 text-muted-foreground">
-          <HugeiconsIcon icon={Image01Icon} className="size-3.5" />
-        </div>
-      )}
-      <Button
-        type="button"
-        variant="outline"
-        size="icon"
-        className="size-8"
-        onClick={() => inputRef.current?.click()}
-        disabled={uploadState.isUploading}
-        aria-label={favicon ? "Replace favicon" : "Upload favicon"}
-      >
-        {uploadState.isUploading ? (
-          <Spinner className="size-3" />
-        ) : (
-          <HugeiconsIcon icon={Upload01Icon} className="size-3" />
-        )}
-      </Button>
-      <Button
-        type="button"
-        variant="ghost"
-        size="icon"
-        className="size-8"
-        onClick={() => void onChange(undefined)}
-        disabled={!favicon || uploadState.isUploading}
-        aria-label="Remove favicon"
-      >
-        <HugeiconsIcon icon={Delete01Icon} className="size-3.5" />
-      </Button>
-    </div>
+    <ImageAssetDropZone
+      alt="Favicon"
+      isRemoving={isRemoving}
+      isUploading={uploadState.isUploading}
+      onFileAccepted={(file) => void upload(file)}
+      onRemove={() => void remove()}
+      progress={uploadState.progress?.percentage}
+      src={favicon}
+    />
   );
 }

--- a/apps/web/features/editor/settings/image-asset-dropzone.tsx
+++ b/apps/web/features/editor/settings/image-asset-dropzone.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { DropZone } from "@/components/file-viewer/file-ui";
+import { Button } from "@baseblocks/ui/button";
+import { Spinner } from "@baseblocks/ui/spinner";
+import { Delete01Icon, Image01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import Image from "next/image";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@baseblocks/ui/tooltip";
+
+export function ImageAssetDropZone({
+  alt,
+  isRemoving = false,
+  isUploading,
+  onFileAccepted,
+  onRemove,
+  progress,
+  src,
+}: {
+  alt: string;
+  isRemoving?: boolean;
+  isUploading: boolean;
+  onFileAccepted: (file: File) => void;
+  onRemove?: () => void;
+  progress?: number;
+  src?: string;
+}) {
+  return (
+    <DropZone
+      accept={{
+        "image/*": [".ico", ".jpg", ".jpeg", ".png", ".gif", ".webp", ".svg"],
+      }}
+      className="group flex h-20 w-28 items-center justify-center overflow-hidden border bg-background transition-[border-color,background-color] focus-within:ring-2 focus-within:ring-ring/50"
+      disabled={isUploading || isRemoving}
+      inputAriaLabel={src ? `Replace ${alt}` : `Upload ${alt}`}
+      maxSize={5 * 1024 * 1024}
+      multiple={false}
+      onFilesAccepted={(files) => {
+        const file = files[0];
+        if (file) onFileAccepted(file);
+      }}
+    >
+      {isUploading || isRemoving ? (
+        <div className="flex flex-col items-center gap-1.5 text-muted-foreground">
+          <Spinner className="size-4" />
+          {isUploading ? (
+            <span className="text-xs tabular-nums">{progress ?? 0}%</span>
+          ) : null}
+        </div>
+      ) : src ? (
+        <div className="relative size-full p-2">
+          <Image
+            alt={alt}
+            className="size-full object-contain"
+            height={64}
+            src={src}
+            unoptimized
+            width={96}
+          />
+          <span className="absolute inset-x-0 bottom-0 bg-background/90 py-1 text-center text-[11px] text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
+            Replace
+          </span>
+          {onRemove ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  aria-label={`Remove ${alt}`}
+                  className="absolute top-1 end-1 size-7 bg-background/90 text-muted-foreground opacity-100 shadow-sm transition-opacity group-focus-within:opacity-100 hover:text-destructive sm:opacity-0 sm:group-hover:opacity-100"
+                  onClick={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    onRemove();
+                  }}
+                  onPointerDown={(event) => event.stopPropagation()}
+                  size="icon-xs"
+                  type="button"
+                  variant="ghost"
+                >
+                  <HugeiconsIcon aria-hidden icon={Delete01Icon} />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent sideOffset={6}>Remove</TooltipContent>
+            </Tooltip>
+          ) : null}
+        </div>
+      ) : (
+        <HugeiconsIcon
+          aria-hidden
+          className="size-5 text-muted-foreground"
+          icon={Image01Icon}
+        />
+      )}
+    </DropZone>
+  );
+}

--- a/apps/web/features/editor/settings/site-appearance-settings.tsx
+++ b/apps/web/features/editor/settings/site-appearance-settings.tsx
@@ -5,7 +5,6 @@ import {
   DEFAULT_CUSTOM_BRAND_COLOR,
   DEFAULT_SITE_SIDEBAR_VARIANT,
   getSiteThemePreviewColors,
-  isValidBrandColor,
   normalizeBrandColor,
   resolveSiteTheme,
   type SiteThemePaletteId,
@@ -13,15 +12,7 @@ import {
   type SiteThemeSettings,
   type SiteThemeStyleId,
 } from "@baseblocks/domain";
-import { Button } from "@baseblocks/ui/button";
-import { ColorPicker } from "@baseblocks/ui/color-picker";
 import { Label } from "@baseblocks/ui/label";
-import { Spinner } from "@baseblocks/ui/spinner";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@baseblocks/ui/popover";
 import {
   Select,
   SelectContent,
@@ -32,6 +23,8 @@ import {
 import { useMutation } from "convex/react";
 import { useId, useState } from "react";
 import { toast } from "sonner";
+import { CustomBrandColor } from "./custom-brand-color";
+import { SiteSettingsSectionTitle } from "./site-settings-section-title";
 
 const PALETTE_OPTIONS: Array<{
   id: Exclude<SiteThemePaletteId, "custom">;
@@ -81,21 +74,32 @@ export function SiteAppearanceSettings({
   );
   const [isSaving, setIsSaving] = useState(false);
   const [isColorPickerOpen, setIsColorPickerOpen] = useState(false);
+  const paletteInputId = useId();
+  const styleInputId = useId();
+  const sidebarInputId = useId();
   const customColorInputId = useId();
 
-  const saveTheme = async (nextTheme: SiteThemeSettings) => {
+  const saveAppearance = async (
+    settings:
+      | { theme: SiteThemeSettings }
+      | { sidebarVariant: SiteSidebarVariant },
+    errorMessage = "Unable to update the site appearance. Try again.",
+  ) => {
     if (isSaving) return false;
     setIsSaving(true);
     try {
-      await updateSite({ siteId, settings: { theme: nextTheme } });
+      await updateSite({ siteId, settings });
       return true;
-    } catch (_error) {
-      toast.error("Failed to update site appearance");
+    } catch {
+      toast.error(errorMessage);
       return false;
     } finally {
       setIsSaving(false);
     }
   };
+
+  const saveTheme = (nextTheme: SiteThemeSettings) =>
+    saveAppearance({ theme: nextTheme });
 
   const selectPalette = (palette: SiteThemePaletteId) => {
     if (palette === resolvedTheme.palette) return;
@@ -133,185 +137,118 @@ export function SiteAppearanceSettings({
     )?.label ?? "Standard";
 
   return (
-    <div className="space-y-4">
-      <div className="space-y-2">
-        <p className="text-xs font-medium text-muted-foreground">Brand color</p>
-        <Select
-          disabled={isSaving}
-          onValueChange={(value) => selectPalette(value as SiteThemePaletteId)}
-          value={resolvedTheme.palette}
-        >
-          <SelectTrigger aria-label="Brand color" className="w-full">
-            <SelectValue>
-              <PaletteIndicator
-                brandColor={customColor}
-                palette={resolvedTheme.palette}
-                style={resolvedTheme.style}
-              />
-              {selectedPaletteLabel}
-            </SelectValue>
-          </SelectTrigger>
-          <SelectContent align="start">
-            {ALL_PALETTE_OPTIONS.map((option) => (
-              <SelectItem key={option.id} value={option.id}>
-                <PaletteIndicator
-                  brandColor={customColor}
-                  palette={option.id}
-                  style={resolvedTheme.style}
-                />
-                {option.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </div>
-
-      {resolvedTheme.palette === "custom" ? (
-        <div className="space-y-2">
-          <Label
-            className="text-xs font-medium text-muted-foreground"
-            htmlFor={customColorInputId}
-          >
-            Custom brand color
-          </Label>
-          <Popover
-            onOpenChange={(open) => {
-              if (open) {
-                setCustomColor(
-                  resolvedTheme.brandColor ?? DEFAULT_CUSTOM_BRAND_COLOR,
-                );
-              } else if (!isSaving) {
-                setCustomColor(
-                  resolvedTheme.brandColor ?? DEFAULT_CUSTOM_BRAND_COLOR,
-                );
+    <div className="space-y-10" aria-busy={isSaving}>
+      <section className="space-y-4">
+        <SiteSettingsSectionTitle>Theme</SiteSettingsSectionTitle>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div className="space-y-2">
+            <Label htmlFor={paletteInputId}>Brand color</Label>
+            <Select
+              disabled={isSaving}
+              onValueChange={(value) =>
+                selectPalette(value as SiteThemePaletteId)
               }
-              setIsColorPickerOpen(open);
-            }}
-            open={isColorPickerOpen}
-          >
-            <PopoverTrigger asChild>
-              <Button
-                className="h-10 w-full justify-start px-3 font-normal"
-                disabled={isSaving}
-                id={customColorInputId}
-                type="button"
-                variant="outline"
-              >
-                <span
-                  aria-hidden
-                  className="size-5 rounded-md border border-black/10 shadow-xs dark:border-white/15"
-                  style={{
-                    backgroundColor:
-                      normalizeBrandColor(customColor) ??
-                      DEFAULT_CUSTOM_BRAND_COLOR,
-                  }}
-                />
-                <span className="font-mono text-xs uppercase">
-                  {normalizeBrandColor(customColor) ??
-                    DEFAULT_CUSTOM_BRAND_COLOR}
-                </span>
-              </Button>
-            </PopoverTrigger>
-            <PopoverContent align="start" className="w-72 space-y-3 p-3">
-              <ColorPicker
-                disabled={isSaving}
-                onValueChange={setCustomColor}
-                value={
-                  normalizeBrandColor(customColor) ?? DEFAULT_CUSTOM_BRAND_COLOR
-                }
-              />
-              <div className="flex justify-end gap-2 border-t pt-3">
-                <Button
-                  disabled={isSaving}
-                  onClick={() => {
-                    setCustomColor(
-                      resolvedTheme.brandColor ?? DEFAULT_CUSTOM_BRAND_COLOR,
-                    );
-                    setIsColorPickerOpen(false);
-                  }}
-                  size="sm"
-                  type="button"
-                  variant="ghost"
-                >
-                  Cancel
-                </Button>
-                <Button
-                  disabled={isSaving || !isValidBrandColor(customColor)}
-                  onClick={() => void applyCustomColor()}
-                  size="sm"
-                  type="button"
-                >
-                  {isSaving ? (
-                    <>
-                      <Spinner />
-                      Applying...
-                    </>
-                  ) : (
-                    "Apply"
-                  )}
-                </Button>
-              </div>
-            </PopoverContent>
-          </Popover>
+              value={resolvedTheme.palette}
+            >
+              <SelectTrigger id={paletteInputId} className="w-full">
+                <SelectValue>
+                  <PaletteIndicator
+                    brandColor={customColor}
+                    palette={resolvedTheme.palette}
+                    style={resolvedTheme.style}
+                  />
+                  {selectedPaletteLabel}
+                </SelectValue>
+              </SelectTrigger>
+              <SelectContent align="start">
+                {ALL_PALETTE_OPTIONS.map((option) => (
+                  <SelectItem key={option.id} value={option.id}>
+                    <PaletteIndicator
+                      brandColor={customColor}
+                      palette={option.id}
+                      style={resolvedTheme.style}
+                    />
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor={styleInputId}>Theme style</Label>
+            <Select
+              disabled={isSaving}
+              onValueChange={(value) =>
+                void saveTheme({
+                  ...resolvedTheme,
+                  style: value as SiteThemeStyleId,
+                })
+              }
+              value={resolvedTheme.style}
+            >
+              <SelectTrigger id={styleInputId} className="w-full">
+                <SelectValue>{selectedStyleLabel}</SelectValue>
+              </SelectTrigger>
+              <SelectContent align="start">
+                {STYLE_OPTIONS.map((option) => (
+                  <SelectItem key={option.id} value={option.id}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {resolvedTheme.palette === "custom" ? (
+            <CustomBrandColor
+              color={customColor}
+              disabled={isSaving}
+              inputId={customColorInputId}
+              onApply={() => void applyCustomColor()}
+              onColorChange={setCustomColor}
+              onOpenChange={(open) => {
+                setCustomColor(
+                  resolvedTheme.brandColor ?? DEFAULT_CUSTOM_BRAND_COLOR,
+                );
+                setIsColorPickerOpen(open);
+              }}
+              open={isColorPickerOpen}
+            />
+          ) : null}
         </div>
-      ) : null}
+      </section>
 
-      <div className="space-y-2">
-        <p className="text-xs font-medium text-muted-foreground">Theme style</p>
-        <Select
-          disabled={isSaving}
-          onValueChange={(value) =>
-            void saveTheme({
-              ...resolvedTheme,
-              style: value as SiteThemeStyleId,
-            })
-          }
-          value={resolvedTheme.style}
-        >
-          <SelectTrigger aria-label="Theme style" className="w-full">
-            <SelectValue>{selectedStyleLabel}</SelectValue>
-          </SelectTrigger>
-          <SelectContent align="start">
-            {STYLE_OPTIONS.map((option) => (
-              <SelectItem key={option.id} value={option.id}>
-                {option.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </div>
-
-      <div className="space-y-2">
-        <p className="text-xs font-medium text-muted-foreground">
-          Sidebar style
-        </p>
-        <Select
-          disabled={isSaving}
-          onValueChange={(value) => {
-            const nextVariant = value as SiteSidebarVariant;
-            if (nextVariant === resolvedSidebarVariant) return;
-            setIsSaving(true);
-            void updateSite({
-              siteId,
-              settings: { sidebarVariant: nextVariant },
-            })
-              .catch(() => toast.error("Failed to update sidebar style"))
-              .finally(() => setIsSaving(false));
-          }}
-          value={resolvedSidebarVariant}
-        >
-          <SelectTrigger aria-label="Sidebar style" className="w-full">
-            <SelectValue>{selectedSidebarVariantLabel}</SelectValue>
-          </SelectTrigger>
-          <SelectContent align="start">
-            {SIDEBAR_VARIANT_OPTIONS.map((option) => (
-              <SelectItem key={option.id} value={option.id}>
-                {option.label}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </div>
+      <section className="space-y-4">
+        <SiteSettingsSectionTitle>Layout</SiteSettingsSectionTitle>
+        <div className="space-y-2">
+          <Label htmlFor={sidebarInputId}>Sidebar style</Label>
+          <Select
+            disabled={isSaving}
+            onValueChange={(value) =>
+              void saveAppearance(
+                { sidebarVariant: value as SiteSidebarVariant },
+                "Unable to update the sidebar style. Try again.",
+              )
+            }
+            value={resolvedSidebarVariant}
+          >
+            <SelectTrigger id={sidebarInputId} className="w-full">
+              <SelectValue>{selectedSidebarVariantLabel}</SelectValue>
+            </SelectTrigger>
+            <SelectContent align="start">
+              {SIDEBAR_VARIANT_OPTIONS.map((option) => (
+                <SelectItem key={option.id} value={option.id}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </section>
+      <span className="sr-only" role="status">
+        {isSaving ? "Saving appearance" : ""}
+      </span>
     </div>
   );
 }

--- a/apps/web/features/editor/settings/site-brand-settings.tsx
+++ b/apps/web/features/editor/settings/site-brand-settings.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useImageUpload } from "@/lib/files/use-image-upload";
+import { api } from "@baseblocks/backend";
+import type { Doc } from "@baseblocks/backend";
+import { Button } from "@baseblocks/ui/button";
+import { Input } from "@baseblocks/ui/input";
+import { Label } from "@baseblocks/ui/label";
+import { Spinner } from "@baseblocks/ui/spinner";
+import { useMutation } from "convex/react";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { FaviconSettings } from "./favicon-settings";
+import { ImageAssetDropZone } from "./image-asset-dropzone";
+import { SiteSettingsSectionTitle } from "./site-settings-section-title";
+
+export function SiteBrandSettings({
+  site,
+}: {
+  site: Doc<"sites"> & { logoUrl?: string };
+}) {
+  const siteId = site._id;
+  const updateSite = useMutation(api.sites.update);
+  const { uploadImage, uploadState } = useImageUpload();
+  const [name, setName] = useState(site.name);
+  const [isSavingName, setIsSavingName] = useState(false);
+  const [isRemovingLogo, setIsRemovingLogo] = useState(false);
+
+  useEffect(() => setName(site.name), [site.name]);
+
+  const saveName = async () => {
+    const normalizedName = name.trim();
+    if (!normalizedName || normalizedName === site.name || isSavingName) return;
+    setIsSavingName(true);
+    try {
+      await updateSite({ siteId, name: normalizedName });
+      setName(normalizedName);
+      toast.success("Site name updated");
+    } catch {
+      toast.error("Unable to update the site name. Try again.");
+    } finally {
+      setIsSavingName(false);
+    }
+  };
+
+  const uploadLogo = async (file?: File) => {
+    if (!file) return;
+    if (!file.type.startsWith("image/")) {
+      toast.error("Select an image file.");
+      return;
+    }
+    if (file.size > 5 * 1024 * 1024) {
+      toast.error("Select an image smaller than 5 MB.");
+      return;
+    }
+    const result = await uploadImage(file, siteId);
+    if (!result) {
+      toast.error(uploadState.error ?? "Unable to upload the logo. Try again.");
+      return;
+    }
+    try {
+      await updateSite({ siteId, logoFileId: result.fileId });
+      toast.success("Logo uploaded");
+    } catch {
+      toast.error("Unable to save the logo. Try again.");
+    }
+  };
+
+  const removeLogo = async () => {
+    if (isRemovingLogo) return;
+    setIsRemovingLogo(true);
+    try {
+      await updateSite({ siteId, clearLogo: true });
+      toast.success("Logo removed");
+    } catch {
+      toast.error("Unable to remove the logo. Try again.");
+    } finally {
+      setIsRemovingLogo(false);
+    }
+  };
+
+  return (
+    <div className="space-y-10">
+      <section className="space-y-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <SiteSettingsSectionTitle>Site details</SiteSettingsSectionTitle>
+          <Button
+            disabled={isSavingName || name.trim() === site.name || !name.trim()}
+            onClick={() => void saveName()}
+            size="compact"
+          >
+            {isSavingName ? <Spinner className="size-3.5" /> : null}
+            Save changes
+          </Button>
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="site-name">Name</Label>
+          <Input
+            className="text-base sm:text-sm"
+            id="site-name"
+            onChange={(event) => setName(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") void saveName();
+              if (event.key === "Escape") setName(site.name);
+            }}
+            value={name}
+          />
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <SiteSettingsSectionTitle>Brand assets</SiteSettingsSectionTitle>
+        <AssetRow label="Logo">
+          <ImageAssetDropZone
+            alt="Site logo"
+            isUploading={uploadState.isUploading}
+            isRemoving={isRemovingLogo}
+            onFileAccepted={(file) => void uploadLogo(file)}
+            onRemove={() => void removeLogo()}
+            progress={uploadState.progress?.percentage}
+            src={site.logoUrl}
+          />
+        </AssetRow>
+        <AssetRow label="Favicon">
+          <FaviconSettings
+            favicon={site.settings.favicon}
+            siteId={siteId}
+            onChange={async (favicon) => {
+              await updateSite(
+                favicon
+                  ? { siteId, settings: { favicon } }
+                  : { siteId, clearFavicon: true },
+              );
+            }}
+          />
+        </AssetRow>
+      </section>
+    </div>
+  );
+}
+
+function AssetRow({
+  children,
+  label,
+}: {
+  children: React.ReactNode;
+  label: string;
+}) {
+  return (
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      <div>
+        <p className="text-sm font-medium">{label}</p>
+      </div>
+      <div className="flex shrink-0 items-center gap-3">{children}</div>
+    </div>
+  );
+}

--- a/apps/web/features/editor/settings/site-navigation-settings.tsx
+++ b/apps/web/features/editor/settings/site-navigation-settings.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { api } from "@baseblocks/backend";
+import type { Doc } from "@baseblocks/backend";
+import { Label } from "@baseblocks/ui/label";
+import { Switch } from "@baseblocks/ui/switch";
+import { useMutation } from "convex/react";
+import { toast } from "sonner";
+import { SiteSettingsSectionTitle } from "./site-settings-section-title";
+
+type BooleanSiteSetting =
+  | "showSiteName"
+  | "showLogo"
+  | "showHeaderSearch"
+  | "expandNavigationByDefault";
+
+export function SiteNavigationSettings({ site }: { site: Doc<"sites"> }) {
+  const updateSite = useMutation(api.sites.update);
+  const updateSetting = async (key: BooleanSiteSetting, value: boolean) => {
+    try {
+      await updateSite({ siteId: site._id, settings: { [key]: value } });
+    } catch {
+      toast.error("Unable to update this setting. Try again.");
+    }
+  };
+
+  return (
+    <div className="space-y-10">
+      <SettingsGroup title="Branding">
+        <SettingRow
+          checked={site.settings.showSiteName !== false}
+          id="show-site-name"
+          label="Show site name"
+          onChange={(value) => updateSetting("showSiteName", value)}
+        />
+        <SettingRow
+          checked={site.settings.showLogo !== false}
+          id="show-logo"
+          label="Show logo"
+          onChange={(value) => updateSetting("showLogo", value)}
+        />
+      </SettingsGroup>
+      <SettingsGroup title="Browsing">
+        <SettingRow
+          checked={site.settings.showHeaderSearch === true}
+          id="show-header-search"
+          label="Search in header"
+          onChange={(value) => updateSetting("showHeaderSearch", value)}
+        />
+        <SettingRow
+          checked={site.settings.expandNavigationByDefault === true}
+          id="expand-navigation-by-default"
+          label="Expand pages by default"
+          onChange={(value) =>
+            updateSetting("expandNavigationByDefault", value)
+          }
+        />
+      </SettingsGroup>
+    </div>
+  );
+}
+
+function SettingsGroup({
+  children,
+  title,
+}: {
+  children: React.ReactNode;
+  title: string;
+}) {
+  return (
+    <section className="space-y-5">
+      <SiteSettingsSectionTitle>{title}</SiteSettingsSectionTitle>
+      {children}
+    </section>
+  );
+}
+
+function SettingRow({
+  checked,
+  id,
+  label,
+  onChange,
+}: {
+  checked: boolean;
+  id: string;
+  label: string;
+  onChange: (value: boolean) => void;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-6 py-1">
+      <Label htmlFor={id}>{label}</Label>
+      <Switch checked={checked} id={id} onCheckedChange={onChange} />
+    </div>
+  );
+}

--- a/apps/web/features/editor/settings/site-settings-section-title.tsx
+++ b/apps/web/features/editor/settings/site-settings-section-title.tsx
@@ -1,0 +1,9 @@
+import { cn } from "@baseblocks/ui/lib/utils";
+import type { ComponentProps } from "react";
+
+export function SiteSettingsSectionTitle({
+  className,
+  ...props
+}: ComponentProps<"h4">) {
+  return <h4 className={cn("text-sm font-medium", className)} {...props} />;
+}

--- a/apps/web/features/editor/site-settings-dialog.tsx
+++ b/apps/web/features/editor/site-settings-dialog.tsx
@@ -1,16 +1,7 @@
 "use client";
 
-import { useImageUpload } from "@/lib/files/use-image-upload";
-import { DropZone } from "@/components/file-viewer/file-ui";
 import { useEditorWorkspace } from "@/features/editor/editor-state";
-import { api } from "@baseblocks/backend";
-import type { Id } from "@baseblocks/backend";
-import {
-  Image01Icon,
-  Navigation03Icon,
-  PaintBrush01Icon,
-} from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
+import { api, type Id } from "@baseblocks/backend";
 import {
   DEFAULT_SITE_SIDEBAR_VARIANT,
   DEFAULT_SITE_THEME,
@@ -22,27 +13,26 @@ import {
   DialogDescription,
   DialogTitle,
 } from "@baseblocks/ui/dialog";
-import { Input } from "@baseblocks/ui/input";
-import { Label } from "@baseblocks/ui/label";
+import { cn } from "@baseblocks/ui/lib/utils";
 import { Spinner } from "@baseblocks/ui/spinner";
-import { Switch } from "@baseblocks/ui/switch";
 import {
-  Sidebar,
-  SidebarContent,
-  SidebarGroup,
-  SidebarGroupContent,
-  SidebarHeader,
-  SidebarMenu,
-  SidebarMenuButton,
-  SidebarMenuItem,
-  SidebarProvider,
-} from "@baseblocks/ui/sidebar";
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@baseblocks/ui/tooltip";
+import {
+  ArrowReloadHorizontalIcon,
+  ColorPickerIcon,
+  IdentityCardIcon,
+  SidebarLeftIcon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { useMutation } from "convex/react";
-import Image from "next/image";
 import { useRef, useState } from "react";
 import { toast } from "sonner";
-import { FaviconSettings } from "./settings/favicon-settings";
 import { SiteAppearanceSettings } from "./settings/site-appearance-settings";
+import { SiteBrandSettings } from "./settings/site-brand-settings";
+import { SiteNavigationSettings } from "./settings/site-navigation-settings";
 
 interface SiteSettingsDialogProps {
   onOpenChange: (open: boolean) => void;
@@ -52,225 +42,23 @@ interface SiteSettingsDialogProps {
 
 type SiteSettingsSection = "brand" | "appearance" | "navigation";
 
-function SettingsSection({
-  action,
-  children,
-  title,
-}: {
-  action?: React.ReactNode;
-  children: React.ReactNode;
-  title: string;
-}) {
-  return (
-    <section className="space-y-3">
-      <div className="flex min-h-7 items-center justify-between gap-3 px-0.5">
-        <h4 className="text-sm font-medium">{title}</h4>
-        {action}
-      </div>
-      {children}
-    </section>
-  );
-}
-
-function SettingSurface({
-  children,
-  label,
-}: {
-  children: React.ReactNode;
-  label: string;
-}) {
-  return (
-    <div className="rounded-lg bg-muted/25 p-3">
-      <p className="mb-2 text-xs font-medium text-muted-foreground">{label}</p>
-      {children}
-    </div>
-  );
-}
-
-function PanelSettingRow({
-  control,
-  htmlFor,
-  label,
-}: {
-  control: React.ReactNode;
-  htmlFor?: string;
-  label: string;
-}) {
-  return (
-    <div className="flex items-center justify-between gap-4 rounded-lg px-2 py-2.5 transition-colors hover:bg-muted/30">
-      <div className="min-w-0 flex-1 pr-2">
-        <Label className="text-sm font-medium leading-none" htmlFor={htmlFor}>
-          {label}
-        </Label>
-      </div>
-      <div className="shrink-0">{control}</div>
-    </div>
-  );
-}
-
-function LogoUploadSection({
-  fileInputRef,
-  isUploading,
-  logoUrl,
-  onFilesAccepted,
-  onRemove,
-  uploadProgress,
-}: {
-  fileInputRef: React.RefObject<HTMLInputElement | null>;
-  isUploading: boolean;
-  logoUrl?: string;
-  onFilesAccepted: (files: File[]) => void;
-  onRemove: () => void;
-  uploadProgress: number;
-}) {
-  if (logoUrl) {
-    return (
-      <div className="flex items-center gap-3">
-        <Image
-          src={logoUrl}
-          alt="Site logo"
-          className="h-10 w-10 rounded-md border border-border/60 bg-background object-contain"
-          width={40}
-          height={40}
-          unoptimized
-        />
-        <div className="flex min-w-0 flex-1 items-center gap-2">
-          <input
-            ref={fileInputRef}
-            type="file"
-            accept="image/*"
-            className="hidden"
-            onChange={(event) => {
-              const files = Array.from(event.target.files || []);
-              if (files.length > 0) {
-                onFilesAccepted(files);
-              }
-              event.target.value = "";
-            }}
-          />
-          <Button
-            variant="outline"
-            size="sm"
-            className="h-8"
-            onClick={() => fileInputRef.current?.click()}
-            disabled={isUploading}
-          >
-            {isUploading ? (
-              <>
-                <Spinner className="mr-1 size-3" />
-                {uploadProgress}%
-              </>
-            ) : (
-              "Replace"
-            )}
-          </Button>
-          <Button
-            className="h-8"
-            disabled={isUploading}
-            onClick={onRemove}
-            size="sm"
-            type="button"
-            variant="ghost"
-          >
-            Remove
-          </Button>
-        </div>
-      </div>
-    );
-  }
-
-  return (
-    <div>
-      <DropZone
-        onFilesAccepted={onFilesAccepted}
-        accept={{
-          "image/*": [".jpg", ".jpeg", ".png", ".gif", ".webp", ".svg"],
-        }}
-        maxSize={5 * 1024 * 1024}
-        className="border-dashed bg-background/40 py-5"
-      >
-        <div className="flex flex-col items-center justify-center gap-1 text-center">
-          {isUploading ? (
-            <>
-              <Spinner className="size-4 text-muted-foreground" />
-              <p className="text-xs text-muted-foreground">{uploadProgress}%</p>
-            </>
-          ) : (
-            <p className="text-xs text-muted-foreground">
-              Drop an image here, or click to browse
-            </p>
-          )}
-        </div>
-      </DropZone>
-    </div>
-  );
-}
-
-function SiteNameSection({
-  displayName,
-  editValue,
-  isEditing,
-  onCancel,
-  onChange,
-  onEdit,
-  onSave,
-}: {
-  displayName: string;
-  editValue: string;
-  isEditing: boolean;
-  onCancel: () => void;
-  onChange: (value: string) => void;
-  onEdit: () => void;
-  onSave: () => void;
-}) {
-  return (
-    <div>
-      {isEditing ? (
-        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-          <Input
-            value={editValue}
-            onChange={(event) => onChange(event.target.value)}
-            aria-label="Site name"
-            className="h-8 text-sm sm:min-w-0 sm:flex-1"
-            onKeyDown={(event) => {
-              if (event.key === "Enter") onSave();
-              if (event.key === "Escape") onCancel();
-            }}
-          />
-          <div className="flex shrink-0 gap-2">
-            <Button size="sm" className="h-8" onClick={onSave}>
-              Save
-            </Button>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              className="h-8"
-              onClick={onCancel}
-            >
-              Cancel
-            </Button>
-          </div>
-        </div>
-      ) : (
-        <div className="flex items-center gap-2">
-          <span className="min-w-0 flex-1 truncate text-sm">
-            {displayName.trim() ? displayName : "Untitled site"}
-          </span>
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            className="h-7 shrink-0 px-2 text-xs"
-            onClick={onEdit}
-          >
-            Edit
-          </Button>
-        </div>
-      )}
-    </div>
-  );
-}
+const SECTIONS = [
+  {
+    id: "brand" as const,
+    icon: IdentityCardIcon,
+    label: "Brand",
+  },
+  {
+    id: "appearance" as const,
+    icon: ColorPickerIcon,
+    label: "Appearance",
+  },
+  {
+    id: "navigation" as const,
+    icon: SidebarLeftIcon,
+    label: "Navigation",
+  },
+];
 
 export function SiteSettingsDialog({
   onOpenChange,
@@ -280,88 +68,12 @@ export function SiteSettingsDialog({
   const { site: workspaceSite } = useEditorWorkspace();
   const site = workspaceSite?._id === siteId ? workspaceSite : null;
   const updateSite = useMutation(api.sites.update);
-  const { uploadImage, uploadState } = useImageUpload();
-  const fileInputRef = useRef<HTMLInputElement>(null);
-  const titleRef = useRef<HTMLHeadingElement>(null);
-  const [localName, setLocalName] = useState("");
-  const [isEditingName, setIsEditingName] = useState(false);
-  const [isResettingAppearance, setIsResettingAppearance] = useState(false);
+  const sectionTitleRef = useRef<HTMLHeadingElement>(null);
   const [section, setSection] = useState<SiteSettingsSection>("brand");
+  const [isResettingAppearance, setIsResettingAppearance] = useState(false);
+  const activeSection = SECTIONS.find((item) => item.id === section)!;
 
-  const isUploading = uploadState.isUploading;
-  const uploadProgress = uploadState.progress?.percentage || 0;
-
-  const updateSettings = async (settingKey: string, value: boolean) => {
-    if (!site) return;
-    try {
-      await updateSite({
-        siteId,
-        settings: {
-          [settingKey]: value,
-        },
-      });
-    } catch (_error) {
-      toast.error("Failed to update setting");
-    }
-  };
-
-  const handleLogoUpload = async (files: File[]) => {
-    const file = files[0];
-    if (!file) return;
-
-    if (!file.type.startsWith("image/")) {
-      toast.error("Please select an image file");
-      return;
-    }
-
-    const result = await uploadImage(file, siteId);
-
-    if (result) {
-      await updateSite({
-        siteId,
-        logoFileId: result.fileId,
-      });
-      toast.success("Logo uploaded");
-    } else if (uploadState.error) {
-      toast.error(uploadState.error);
-    }
-  };
-
-  const handleSaveName = async () => {
-    const nextName = localName.trim();
-    if (!site || nextName === site.name) {
-      setIsEditingName(false);
-      return;
-    }
-
-    if (!nextName) {
-      toast.error("Enter a site name");
-      return;
-    }
-
-    try {
-      await updateSite({
-        siteId,
-        name: nextName,
-      });
-      setIsEditingName(false);
-      toast.success("Site name updated");
-    } catch (_error) {
-      toast.error("Failed to update name");
-    }
-  };
-
-  const handleRemoveLogo = async () => {
-    if (!site) return;
-    try {
-      await updateSite({ siteId, clearLogo: true });
-      toast.success("Logo removed");
-    } catch (_error) {
-      toast.error("Failed to remove logo");
-    }
-  };
-
-  const handleResetAppearance = async () => {
+  const resetAppearance = async () => {
     setIsResettingAppearance(true);
     try {
       await updateSite({
@@ -371,216 +83,116 @@ export function SiteSettingsDialog({
           theme: DEFAULT_SITE_THEME,
         },
       });
-    } catch (_error) {
-      toast.error("Failed to reset site appearance");
+    } catch {
+      toast.error("Unable to reset the appearance. Try again.");
     } finally {
       setIsResettingAppearance(false);
     }
   };
 
-  const showLogo = site?.settings.showLogo !== false;
-  const showSiteName = site?.settings.showSiteName !== false;
-  const showHeaderSearch = site?.settings.showHeaderSearch === true;
-  const expandNavigationByDefault =
-    site?.settings.expandNavigationByDefault === true;
-
-  const navigation = [
-    { id: "brand" as const, icon: Image01Icon, label: "Brand" },
-    {
-      id: "appearance" as const,
-      icon: PaintBrush01Icon,
-      label: "Appearance",
-    },
-    {
-      id: "navigation" as const,
-      icon: Navigation03Icon,
-      label: "Navigation",
-    },
-  ];
-
   return (
     <Dialog open onOpenChange={onOpenChange}>
       <DialogContent
-        className="h-[min(88vh,42rem)] w-[calc(100%-2rem)] max-w-[56rem] overflow-hidden rounded-[1.5rem] border-sidebar-border bg-background p-0 text-foreground shadow-2xl sm:max-w-[56rem] [&_[data-slot='dialog-close']]:top-4 [&_[data-slot='dialog-close']]:right-4"
+        className="h-[min(88vh,40rem)] w-[calc(100%-1.5rem)] max-w-[52rem] grid-rows-[minmax(0,1fr)] gap-0 overflow-hidden rounded-2xl border-0 bg-background/70 p-0 text-foreground shadow-2xl backdrop-blur-xl backdrop-saturate-150 sm:max-w-[52rem] [&_[data-slot='dialog-close']]:top-2 [&_[data-slot='dialog-close']]:right-2 [&_[data-slot='dialog-close']]:flex [&_[data-slot='dialog-close']]:size-8 [&_[data-slot='dialog-close']]:items-center [&_[data-slot='dialog-close']]:justify-center [&_[data-slot='dialog-close']]:rounded-lg"
         onOpenAutoFocus={(event) => {
           event.preventDefault();
-          titleRef.current?.focus();
+          sectionTitleRef.current?.focus();
         }}
         returnFocusTo={returnFocusTo}
       >
         <DialogDescription className="sr-only">
           Configure the site brand, appearance, and navigation.
         </DialogDescription>
-        <SidebarProvider
-          className="h-full min-h-0 items-stretch"
-          cookieName={null}
-        >
-          <Sidebar
-            className="w-40 border-e border-sidebar-border sm:w-52"
-            collapsible="none"
-          >
-            <SidebarHeader className="h-16 shrink-0 justify-center px-4">
-              <DialogTitle
-                className="text-sm font-semibold focus:outline-none"
-                ref={titleRef}
-                tabIndex={-1}
-              >
-                Site settings
-              </DialogTitle>
-            </SidebarHeader>
-            <SidebarContent>
-              <SidebarGroup className="p-2">
-                <SidebarGroupContent>
-                  <SidebarMenu aria-label="Site settings sections">
-                    {navigation.map((item) => (
-                      <SidebarMenuItem key={item.id}>
-                        <SidebarMenuButton
-                          aria-pressed={section === item.id}
-                          isActive={section === item.id}
-                          onClick={() => setSection(item.id)}
-                        >
-                          <HugeiconsIcon icon={item.icon} />
-                          <span>{item.label}</span>
-                        </SidebarMenuButton>
-                      </SidebarMenuItem>
-                    ))}
-                  </SidebarMenu>
-                </SidebarGroupContent>
-              </SidebarGroup>
-            </SidebarContent>
-          </Sidebar>
+        <DialogTitle className="sr-only">Site settings</DialogTitle>
+        <div className="grid min-h-0 flex-1 grid-cols-[minmax(0,1fr)] grid-rows-[auto_minmax(0,1fr)] md:grid-cols-[11rem_minmax(0,1fr)] md:grid-rows-1">
+          <aside className="bg-sidebar/35 p-2 pe-12 md:pe-2">
+            <nav
+              aria-label="Site settings sections"
+              className="flex gap-1 md:flex-col"
+            >
+              {SECTIONS.map((item) => (
+                <button
+                  aria-current={section === item.id ? "page" : undefined}
+                  className={cn(
+                    "flex h-8 min-w-0 flex-1 items-center justify-center gap-2 rounded-lg px-1.5 text-xs outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring/50 sm:flex-none sm:px-2.5 sm:text-sm md:w-full md:flex-auto md:justify-start",
+                    section === item.id
+                      ? "bg-sidebar-accent text-sidebar-accent-foreground"
+                      : "text-sidebar-foreground/70 hover:bg-sidebar-accent/60 hover:text-sidebar-accent-foreground",
+                  )}
+                  key={item.id}
+                  onClick={() => setSection(item.id)}
+                  type="button"
+                >
+                  <HugeiconsIcon
+                    aria-hidden
+                    className="hidden size-4 sm:block"
+                    icon={item.icon}
+                  />
+                  {item.label}
+                </button>
+              ))}
+            </nav>
+          </aside>
 
-          <main className="min-h-0 min-w-0 flex-1 overflow-y-auto px-5 py-6 sm:px-7">
+          <main className="min-h-0 min-w-0 overflow-y-auto overscroll-contain px-5 pb-6 sm:px-6">
             {!site ? (
               <div className="flex min-h-full items-center justify-center">
                 <Spinner className="size-5 text-muted-foreground" />
+                <span className="sr-only">Loading site settings</span>
               </div>
-            ) : section === "brand" ? (
-              <SettingsSection title="Brand">
-                <div className="space-y-2">
-                  <SettingSurface label="Site name">
-                    <SiteNameSection
-                      displayName={site.name}
-                      editValue={localName}
-                      isEditing={isEditingName}
-                      onCancel={() => {
-                        setLocalName(site.name);
-                        setIsEditingName(false);
-                      }}
-                      onChange={setLocalName}
-                      onEdit={() => {
-                        setLocalName(site.name);
-                        setIsEditingName(true);
-                      }}
-                      onSave={handleSaveName}
-                    />
-                  </SettingSurface>
-                  <SettingSurface label="Logo">
-                    <LogoUploadSection
-                      fileInputRef={fileInputRef}
-                      isUploading={isUploading}
-                      logoUrl={site.logoUrl}
-                      onFilesAccepted={handleLogoUpload}
-                      onRemove={() => void handleRemoveLogo()}
-                      uploadProgress={uploadProgress}
-                    />
-                  </SettingSurface>
-                  <SettingSurface label="Favicon">
-                    <FaviconSettings
-                      favicon={site.settings.favicon}
-                      siteId={siteId}
-                      onChange={async (favicon) => {
-                        await updateSite(
-                          favicon
-                            ? { siteId, settings: { favicon } }
-                            : { siteId, clearFavicon: true },
-                        );
-                      }}
-                    />
-                  </SettingSurface>
-                </div>
-              </SettingsSection>
-            ) : section === "appearance" ? (
-              <SettingsSection
-                title="Appearance"
-                action={
-                  <Button
-                    className="h-7 px-2 text-xs"
-                    disabled={isResettingAppearance}
-                    onClick={() => void handleResetAppearance()}
-                    size="sm"
-                    variant="ghost"
-                  >
-                    Reset
-                  </Button>
-                }
-              >
-                <SiteAppearanceSettings
-                  sidebarVariant={site.settings.sidebarVariant}
-                  siteId={siteId}
-                  theme={site.settings.theme}
-                />
-              </SettingsSection>
             ) : (
-              <SettingsSection title="Navigation">
-                <div className="space-y-0.5">
-                  <PanelSettingRow
-                    htmlFor="show-site-name"
-                    label="Show site name"
-                    control={
-                      <Switch
-                        id="show-site-name"
-                        checked={showSiteName}
-                        onCheckedChange={(checked) =>
-                          updateSettings("showSiteName", checked)
-                        }
-                      />
-                    }
-                  />
-                  <PanelSettingRow
-                    htmlFor="show-logo"
-                    label="Show logo"
-                    control={
-                      <Switch
-                        id="show-logo"
-                        checked={showLogo}
-                        onCheckedChange={(checked) =>
-                          updateSettings("showLogo", checked)
-                        }
-                      />
-                    }
-                  />
-                  <PanelSettingRow
-                    htmlFor="show-header-search"
-                    label="Search in header"
-                    control={
-                      <Switch
-                        id="show-header-search"
-                        checked={showHeaderSearch}
-                        onCheckedChange={(checked) =>
-                          updateSettings("showHeaderSearch", checked)
-                        }
-                      />
-                    }
-                  />
-                  <PanelSettingRow
-                    htmlFor="expand-navigation-by-default"
-                    label="Expand pages by default"
-                    control={
-                      <Switch
-                        id="expand-navigation-by-default"
-                        checked={expandNavigationByDefault}
-                        onCheckedChange={(checked) =>
-                          updateSettings("expandNavigationByDefault", checked)
-                        }
-                      />
-                    }
-                  />
+              <div className="space-y-6">
+                <div className="flex min-h-12 items-center justify-between gap-3 pe-8">
+                  <h3
+                    className="brand-display text-2xl leading-none font-normal tracking-[-0.025em] focus:outline-none"
+                    ref={sectionTitleRef}
+                    tabIndex={-1}
+                  >
+                    {activeSection.label}
+                  </h3>
+                  {section === "appearance" ? (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          aria-label="Reset appearance"
+                          disabled={isResettingAppearance}
+                          onClick={() => void resetAppearance()}
+                          size="icon-sm"
+                          variant="ghost"
+                        >
+                          {isResettingAppearance ? (
+                            <Spinner className="size-3.5" />
+                          ) : (
+                            <HugeiconsIcon
+                              aria-hidden
+                              className="size-4"
+                              icon={ArrowReloadHorizontalIcon}
+                            />
+                          )}
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent sideOffset={6}>
+                        Reset appearance
+                      </TooltipContent>
+                    </Tooltip>
+                  ) : null}
                 </div>
-              </SettingsSection>
+
+                {section === "brand" ? (
+                  <SiteBrandSettings site={site} />
+                ) : section === "appearance" ? (
+                  <SiteAppearanceSettings
+                    sidebarVariant={site.settings.sidebarVariant}
+                    siteId={siteId}
+                    theme={site.settings.theme}
+                  />
+                ) : (
+                  <SiteNavigationSettings site={site} />
+                )}
+              </div>
             )}
           </main>
-        </SidebarProvider>
+        </div>
       </DialogContent>
     </Dialog>
   );


### PR DESCRIPTION
## Summary

- Rebuild the Site Settings dialog to match the workspace settings visual hierarchy.
- Split Brand, Appearance, and Navigation into focused settings components.
- Add consistent clickable image drop zones for the logo and favicon.
- Refine spacing, concentric radii, icon controls, responsive navigation, and the accepted glass surface.
- Preserve site-name validation, logo removal, appearance reset, and navigation behavior.

## User impact

Site settings now use the same clear hierarchy and interaction patterns as the main app settings. The dialog has less copy, consistent asset controls, and a more polished responsive layout.

## Validation

- `bun run lint`
- `bun run check-types`
- `bun test` (203 tests passed)
- `bun run build`
- Manual browser verification on port 3001 across Brand, Appearance, and Navigation
- Browser console: no errors or warnings
- Two-axis standards and requirements review