### PR TITLE
Restore custom block configuration menus

### DIFF
--- a/apps/web/features/openeditor/custom-block-menu.test.ts
+++ b/apps/web/features/openeditor/custom-block-menu.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import { resolveOpenEditorBlockMenu } from "@openeditor/react";
+import { baseBlocksCustomBlockMenuExtension } from "./custom-block-menu";
+
+const configureLabels = (blockId: string) => {
+  const ref = { id: "block-1", nodeType: "customBlock" };
+  const block = {
+    ref,
+    node: {
+      type: "customBlock",
+      attrs: { "openeditor-id": ref.id, blockId, version: 1, data: {} },
+    },
+    attributes: { blockId, version: 1, data: {} },
+  };
+  const target = {
+    ref,
+    read: () => block,
+    getSnapshot: () => block,
+    subscribe: () => () => {},
+    commands: {
+      updateAttributes: () => true,
+      select: () => true,
+      copy: async () => true,
+      duplicate: () => true,
+      delete: () => true,
+      move: () => true,
+      canMove: () => true,
+    },
+  };
+
+  return resolveOpenEditorBlockMenu({
+    target,
+    extensions: [baseBlocksCustomBlockMenuExtension],
+  })
+    .sections.flatMap(({ items }) => items)
+    .filter(({ section }) => section === "configure")
+    .map(({ label }) => label);
+};
+
+describe("BaseBlocks custom block menu", () => {
+  test.each([
+    ["baseblocks.directory", ["Configure"]],
+    ["baseblocks.library", ["Configure"]],
+    ["baseblocks.search", ["Configure"]],
+    ["baseblocks.decision-tree", []],
+    ["baseblocks.quick-links", []],
+  ])("shows the intended configuration for %s", (blockId, expected) => {
+    expect(configureLabels(blockId)).toEqual(expected);
+  });
+});

--- a/apps/web/features/openeditor/custom-block-menu.tsx
+++ b/apps/web/features/openeditor/custom-block-menu.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { LibrarySettings } from "@/features/openeditor/extensions/library";
+import { SearchSettings } from "@/features/openeditor/extensions/search";
+import { directoryBlock } from "@baseblocks/custom-blocks";
+import {
+  libraryBlock,
+  searchBlock,
+} from "@baseblocks/openeditor-contracts/core-blocks";
+import { Label } from "@baseblocks/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@baseblocks/ui/select";
+import { CogIcon } from "@hugeicons/core-free-icons";
+import {
+  type OpenEditorBlockPanelProps,
+  useOpenEditorBlockTarget,
+} from "@openeditor/react";
+
+const pageSizes = [5, 10, 20, 50] as const;
+
+function DirectorySettingsPanel({ target }: OpenEditorBlockPanelProps) {
+  const block = useOpenEditorBlockTarget(target);
+  if (!block) return null;
+  const value = directoryBlock.parseData(block.attributes.data);
+  const updatePageSize = (directoryId: string, pageSize: number | null) =>
+    target.commands.updateAttributes({
+      data: {
+        directories: value.directories.map((directory) =>
+          directory.id === directoryId ? { ...directory, pageSize } : directory,
+        ),
+      },
+    });
+
+  return (
+    <div className="w-72 p-4">
+      <h2 className="mb-4 font-medium text-sm">Directory settings</h2>
+      <div className="grid gap-4">
+        {value.directories.map((directory) => {
+          const id = `directory-page-size-${directory.id}`;
+          return (
+            <div className="grid gap-1.5" key={directory.id}>
+              <Label
+                className="text-xs font-medium tracking-wide text-sidebar-foreground/55"
+                htmlFor={id}
+              >
+                {value.directories.length > 1
+                  ? `${directory.label} rows displayed`
+                  : "Rows displayed"}
+              </Label>
+              <Select
+                onValueChange={(next) =>
+                  updatePageSize(
+                    directory.id,
+                    next === "all" ? null : Number(next),
+                  )
+                }
+                value={
+                  directory.pageSize === null
+                    ? "all"
+                    : String(directory.pageSize)
+                }
+              >
+                <SelectTrigger
+                  className="h-10 w-full rounded-[0.95rem] border-sidebar-border/80 bg-background/70 text-sidebar-foreground"
+                  id={id}
+                >
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent className="rounded-[1rem] border-sidebar-border bg-sidebar text-sidebar-foreground shadow-2xl">
+                  <SelectItem value="all">Show all rows</SelectItem>
+                  {pageSizes.map((size) => (
+                    <SelectItem key={size} value={String(size)}>
+                      {size} rows per page
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function LibrarySettingsPanel({ close, target }: OpenEditorBlockPanelProps) {
+  const block = useOpenEditorBlockTarget(target);
+  if (!block) return null;
+  const value = libraryBlock.parseData(block.attributes.data);
+  return (
+    <div className="w-80 p-4">
+      <h2 className="mb-4 font-medium text-sm">Library settings</h2>
+      <LibrarySettings
+        onChange={(data) => target.commands.updateAttributes({ data })}
+        onComplete={close}
+        value={value}
+      />
+    </div>
+  );
+}
+
+function SearchSettingsPanel({ target }: OpenEditorBlockPanelProps) {
+  const block = useOpenEditorBlockTarget(target);
+  if (!block) return null;
+  const value = searchBlock.parseData(block.attributes.data);
+  return (
+    <div className="w-72 p-4">
+      <h2 className="mb-4 font-medium text-sm">Search settings</h2>
+      <SearchSettings
+        onChange={(data) => target.commands.updateAttributes({ data })}
+        value={value}
+      />
+    </div>
+  );
+}
+
+const configuredBlock =
+  (blockId: string) =>
+  ({ block }: { block: { attributes: Readonly<Record<string, unknown>> } }) =>
+    block.attributes.blockId === blockId;
+
+export const baseBlocksCustomBlockMenuExtension = {
+  block: { name: "baseblocks-custom-blocks", nodeType: "customBlock" },
+  blockMenu: {
+    items: [
+      {
+        type: "panel" as const,
+        id: "configure-directory",
+        label: "Configure",
+        icon: CogIcon,
+        section: "configure" as const,
+        when: configuredBlock(directoryBlock.id),
+        panel: DirectorySettingsPanel,
+      },
+      {
+        type: "panel" as const,
+        id: "configure-library",
+        label: "Configure",
+        icon: CogIcon,
+        section: "configure" as const,
+        when: configuredBlock(libraryBlock.id),
+        panel: LibrarySettingsPanel,
+      },
+      {
+        type: "panel" as const,
+        id: "configure-search",
+        label: "Configure",
+        icon: CogIcon,
+        section: "configure" as const,
+        when: configuredBlock(searchBlock.id),
+        panel: SearchSettingsPanel,
+      },
+    ],
+  },
+};

--- a/apps/web/features/openeditor/custom-blocks.tsx
+++ b/apps/web/features/openeditor/custom-blocks.tsx
@@ -23,6 +23,7 @@ import { searchEditor } from "./extensions/search";
 import { baseBlocksCustomBlockRegistry } from "./custom-block-registry";
 import { createBaseBlocksCustomBlockHost } from "./custom-block-host";
 import { createOpenEditorIcon } from "./slash-menu";
+import { baseBlocksCustomBlockMenuExtension } from "./custom-block-menu";
 export { baseBlocksCustomBlockRegistry } from "./custom-block-registry";
 
 const customBlockSlashMenuIcons = {
@@ -135,6 +136,7 @@ export const createBaseBlocksCustomBlockEditorConfiguration = (
     registry: baseBlocksCustomBlockRegistry,
     editors: [...baseBlocksCustomBlockEditors, searchEditor, libraryEditor],
     icons: customBlockSlashMenuIcons,
+    blockMenuExtensions: [baseBlocksCustomBlockMenuExtension],
     host: {
       ...createBaseBlocksCustomBlockHost(authorizedAssetIds, pickAsset),
       fields: { document: DocumentEditor },

--- a/apps/web/features/openeditor/extensions/library.tsx
+++ b/apps/web/features/openeditor/extensions/library.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { HugeiconsIcon } from "@hugeicons/react";
-import { Add01Icon, FolderAddIcon, CogIcon } from "@hugeicons/core-free-icons";
+import { Add01Icon, FolderAddIcon } from "@hugeicons/core-free-icons";
 import {
   PublicLibraryViewer,
   readLibrary,
@@ -16,13 +16,6 @@ import { Button } from "@baseblocks/ui/button";
 import { Input } from "@baseblocks/ui/input";
 import { Label } from "@baseblocks/ui/label";
 import {
-  Popover,
-  PopoverContent,
-  PopoverHeader,
-  PopoverTitle,
-  PopoverTrigger,
-} from "@baseblocks/ui/popover";
-import {
   Select,
   SelectContent,
   SelectItem,
@@ -33,31 +26,29 @@ import { Switch } from "@baseblocks/ui/switch";
 import { defineOpenEditorCustomBlockEditor } from "@openeditor/custom-block/editor";
 import { defineOpenEditorCustomBlockViewer } from "@openeditor/custom-block/viewer";
 import { useMutation, useQuery } from "convex/react";
-import { useState } from "react";
+import { useId, useState } from "react";
 
-function LibraryEditor({
+export function LibrarySettings({
+  onComplete,
   value,
   onChange,
 }: {
+  onComplete?: () => void;
   value: LibraryContent;
   onChange: (value: LibraryContent) => void;
 }) {
   const { siteId } = useSiteRenderActions();
   const createLibrary = useMutation(api.libraries.createLibrary);
-  const [open, setOpen] = useState(false);
   const [newName, setNewName] = useState("");
   const [creating, setCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const newLibraryNameId = useId();
+  const allowDownloadsId = useId();
   const libraries = useQuery(
     api.libraries.listLibraries,
     siteId ? { siteId } : "skip",
   );
   const libraryId = value.libraryId as LibraryId | undefined;
-  const explorer = useQuery(
-    api.libraries.getExplorer,
-    libraryId ? { libraryId } : "skip",
-  );
-
   const create = async () => {
     const name = newName.trim();
     if (!name || !siteId || creating) return;
@@ -67,7 +58,7 @@ function LibraryEditor({
       const nextLibraryId = await createLibrary({ siteId, name });
       onChange({ ...value, libraryId: nextLibraryId });
       setNewName("");
-      setOpen(false);
+      onComplete?.();
     } catch (cause) {
       setError(
         cause instanceof Error ? cause.message : "Could not create library.",
@@ -86,125 +77,117 @@ function LibraryEditor({
   }
 
   return (
-    <div className="flex items-start gap-2">
-      <div className="min-w-0 flex-1">
-        {libraryId ? (
-          <LibraryExplorer
-            allowDownloads={value.allowDownloads !== false}
-            embedded
-            explorer={explorer}
-          />
-        ) : (
-          <button
-            className="flex min-h-20 w-full items-center justify-center gap-2 rounded-2xl border border-dashed text-sm font-medium text-muted-foreground transition hover:border-primary/40 hover:bg-primary/5 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-            onClick={() => setOpen(true)}
-            type="button"
-          >
-            <HugeiconsIcon icon={FolderAddIcon} className="size-4" />
-            Choose or create a library
-          </button>
-        )}
+    <div className="grid gap-4">
+      <div className="grid gap-1.5">
+        <Label className="text-xs font-medium tracking-wide text-sidebar-foreground/55">
+          Library
+        </Label>
+        <Select
+          onValueChange={(next) => onChange({ ...value, libraryId: next })}
+          value={libraryId}
+        >
+          <SelectTrigger className="h-10 w-full rounded-[0.95rem] border-sidebar-border/80 bg-background/70 text-sidebar-foreground">
+            <SelectValue placeholder="Choose a library" />
+          </SelectTrigger>
+          <SelectContent className="rounded-[1rem] border-sidebar-border bg-sidebar text-sidebar-foreground shadow-2xl">
+            {libraries?.map((library) => (
+              <SelectItem
+                className="rounded-[0.7rem] focus:bg-sidebar-accent focus:text-sidebar-accent-foreground"
+                key={library._id}
+                value={library._id}
+              >
+                {library.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       </div>
 
-      <Popover open={open} onOpenChange={setOpen}>
-        <PopoverTrigger asChild>
+      <div className="grid gap-1.5">
+        <Label
+          className="text-xs font-medium tracking-wide text-sidebar-foreground/55"
+          htmlFor={newLibraryNameId}
+        >
+          New library
+        </Label>
+        <div className="flex gap-2">
+          <Input
+            className="h-10 rounded-[0.95rem] border-sidebar-border/80 bg-background/70 text-sidebar-foreground"
+            id={newLibraryNameId}
+            onChange={(event) => {
+              setNewName(event.target.value);
+              setError(null);
+            }}
+            onKeyDown={(event) => {
+              if (event.nativeEvent.isComposing) return;
+              if (event.key === "Enter") void create();
+            }}
+            placeholder="Library name"
+            value={newName}
+          />
           <Button
-            aria-label="Configure library"
-            className="shrink-0 rounded-2xl border-0 bg-card shadow-none hover:bg-muted/60"
+            aria-label="Create library"
+            className="size-10 shrink-0 rounded-full"
+            disabled={!newName.trim() || creating}
+            onClick={() => void create()}
             size="icon"
             type="button"
-            variant="ghost"
           >
-            <HugeiconsIcon icon={CogIcon} className="size-4" />
+            <HugeiconsIcon icon={Add01Icon} className="size-4" />
           </Button>
-        </PopoverTrigger>
-        <PopoverContent
-          align="end"
-          className="w-80 rounded-[1.25rem] border-sidebar-border bg-sidebar p-4 text-sidebar-foreground shadow-2xl"
-        >
-          <PopoverHeader className="mb-4">
-            <PopoverTitle>Library settings</PopoverTitle>
-          </PopoverHeader>
-          <div className="grid gap-4">
-            <div className="grid gap-1.5">
-              <Label className="text-xs font-medium tracking-wide text-sidebar-foreground/55">
-                Library
-              </Label>
-              <Select
-                onValueChange={(next) =>
-                  onChange({ ...value, libraryId: next })
-                }
-                value={libraryId}
-              >
-                <SelectTrigger className="h-10 w-full rounded-[0.95rem] border-sidebar-border/80 bg-background/70 text-sidebar-foreground">
-                  <SelectValue placeholder="Choose a library" />
-                </SelectTrigger>
-                <SelectContent className="rounded-[1rem] border-sidebar-border bg-sidebar text-sidebar-foreground shadow-2xl">
-                  {libraries?.map((library) => (
-                    <SelectItem
-                      className="rounded-[0.7rem] focus:bg-sidebar-accent focus:text-sidebar-accent-foreground"
-                      key={library._id}
-                      value={library._id}
-                    >
-                      {library.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
+        </div>
+        {error ? <p className="text-xs text-destructive">{error}</p> : null}
+      </div>
 
-            <div className="grid gap-1.5">
-              <Label
-                className="text-xs font-medium tracking-wide text-sidebar-foreground/55"
-                htmlFor="new-library-name"
-              >
-                New library
-              </Label>
-              <div className="flex gap-2">
-                <Input
-                  className="h-10 rounded-[0.95rem] border-sidebar-border/80 bg-background/70 text-sidebar-foreground"
-                  id="new-library-name"
-                  onChange={(event) => {
-                    setNewName(event.target.value);
-                    setError(null);
-                  }}
-                  onKeyDown={(event) => {
-                    if (event.key === "Enter") void create();
-                  }}
-                  placeholder="Library name"
-                  value={newName}
-                />
-                <Button
-                  aria-label="Create library"
-                  className="size-10 shrink-0 rounded-full"
-                  disabled={!newName.trim() || creating}
-                  onClick={() => void create()}
-                  size="icon"
-                  type="button"
-                >
-                  <HugeiconsIcon icon={Add01Icon} className="size-4" />
-                </Button>
-              </div>
-              {error ? (
-                <p className="text-xs text-destructive">{error}</p>
-              ) : null}
-            </div>
+      <div className="flex items-center justify-between gap-4">
+        <Label className="text-sm" htmlFor={allowDownloadsId}>
+          Allow downloads
+        </Label>
+        <Switch
+          checked={value.allowDownloads !== false}
+          id={allowDownloadsId}
+          onCheckedChange={(allowDownloads) =>
+            onChange({ ...value, allowDownloads })
+          }
+        />
+      </div>
+    </div>
+  );
+}
 
-            <div className="flex items-center justify-between gap-4">
-              <Label className="text-sm" htmlFor="library-downloads">
-                Allow downloads
-              </Label>
-              <Switch
-                checked={value.allowDownloads !== false}
-                id="library-downloads"
-                onCheckedChange={(allowDownloads) =>
-                  onChange({ ...value, allowDownloads })
-                }
-              />
-            </div>
-          </div>
-        </PopoverContent>
-      </Popover>
+function LibraryEditor({
+  onChange,
+  value,
+}: {
+  onChange: (value: LibraryContent) => void;
+  value: LibraryContent;
+}) {
+  const { siteId } = useSiteRenderActions();
+  const libraryId = value.libraryId as LibraryId | undefined;
+  const explorer = useQuery(
+    api.libraries.getExplorer,
+    libraryId ? { libraryId } : "skip",
+  );
+  if (!siteId) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        Library editing is unavailable outside a site.
+      </p>
+    );
+  }
+  return libraryId ? (
+    <LibraryExplorer
+      allowDownloads={value.allowDownloads !== false}
+      embedded
+      explorer={explorer}
+    />
+  ) : (
+    <div className="rounded-2xl border border-dashed p-4">
+      <div className="mb-4 flex items-center gap-2 text-sm font-medium text-muted-foreground">
+        <HugeiconsIcon icon={FolderAddIcon} className="size-4" />
+        Choose or create a library
+      </div>
+      <LibrarySettings onChange={onChange} value={value} />
     </div>
   );
 }
@@ -214,7 +197,7 @@ export const libraryEditor = defineOpenEditorCustomBlockEditor({
   render: ({ data, updateData }) => (
     <section className="not-prose my-4">
       <LibraryEditor
-        onChange={({ libraryId, allowDownloads }) =>
+        onChange={({ allowDownloads, libraryId }) =>
           updateData({
             ...(libraryId ? { libraryId } : {}),
             allowDownloads: allowDownloads !== false,

--- a/apps/web/features/openeditor/extensions/search.tsx
+++ b/apps/web/features/openeditor/extensions/search.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { HugeiconsIcon } from "@hugeicons/react";
-import { CogIcon } from "@hugeicons/core-free-icons";
 import { useSiteRenderActions } from "@/components/site-runtime/actions";
 import {
   readSearch,
@@ -10,19 +8,12 @@ import {
 import { SearchBox } from "@/features/search";
 import type { SearchContent } from "@baseblocks/domain";
 import { searchBlock } from "@baseblocks/openeditor-contracts/core-blocks";
-import { Button } from "@baseblocks/ui/button";
 import { Input } from "@baseblocks/ui/input";
 import { Label } from "@baseblocks/ui/label";
-import {
-  Popover,
-  PopoverContent,
-  PopoverHeader,
-  PopoverTitle,
-  PopoverTrigger,
-} from "@baseblocks/ui/popover";
 import { Switch } from "@baseblocks/ui/switch";
 import { defineOpenEditorCustomBlockEditor } from "@openeditor/custom-block/editor";
 import { defineOpenEditorCustomBlockViewer } from "@openeditor/custom-block/viewer";
+import { useId } from "react";
 
 function SearchPreview({ value }: { value: Required<SearchContent> }) {
   const { siteId } = useSiteRenderActions();
@@ -45,95 +36,69 @@ function SearchPreview({ value }: { value: Required<SearchContent> }) {
   );
 }
 
-function SearchEditor({
+export function SearchSettings({
   value,
   onChange,
 }: {
   value: Required<SearchContent>;
   onChange: (value: Required<SearchContent>) => void;
 }) {
+  const placeholderId = useId();
+  const maxResultsId = useId();
+  const fileTypesId = useId();
   const update = (patch: Partial<SearchContent>) =>
     onChange({ ...value, ...patch });
   return (
-    <section className="not-prose my-4 flex items-start gap-2">
-      <div className="min-w-0 flex-1">
-        <SearchPreview value={value} />
+    <div className="grid gap-4">
+      <Label
+        className="grid gap-1.5 text-xs font-medium tracking-wide text-sidebar-foreground/55"
+        htmlFor={placeholderId}
+      >
+        Placeholder
+        <Input
+          className="h-9 rounded-[0.85rem] border-sidebar-border/80 bg-background/70 text-sidebar-foreground"
+          id={placeholderId}
+          onChange={(event) => update({ placeholder: event.target.value })}
+          value={value.placeholder}
+        />
+      </Label>
+      <Label
+        className="grid gap-1.5 text-xs font-medium tracking-wide text-sidebar-foreground/55"
+        htmlFor={maxResultsId}
+      >
+        Maximum results
+        <Input
+          className="h-9 rounded-[0.85rem] border-sidebar-border/80 bg-background/70 text-sidebar-foreground"
+          id={maxResultsId}
+          max={50}
+          min={1}
+          onChange={(event) =>
+            update({ maxResults: Number(event.target.value) })
+          }
+          type="number"
+          value={value.maxResults}
+        />
+      </Label>
+      <div className="flex items-center justify-between gap-4">
+        <Label className="text-sm" htmlFor={fileTypesId}>
+          Show file types
+        </Label>
+        <Switch
+          checked={value.showFileType}
+          id={fileTypesId}
+          onCheckedChange={(checked) => update({ showFileType: checked })}
+        />
       </div>
-      <Popover>
-        <PopoverTrigger asChild>
-          <Button
-            aria-label="Configure search"
-            className="shrink-0 rounded-2xl border-0 bg-card shadow-none hover:bg-muted/60"
-            size="icon"
-            type="button"
-            variant="ghost"
-          >
-            <HugeiconsIcon icon={CogIcon} className="size-4" />
-          </Button>
-        </PopoverTrigger>
-        <PopoverContent
-          align="end"
-          className="w-72 rounded-[1.25rem] border-sidebar-border bg-sidebar p-4 text-sidebar-foreground shadow-2xl"
-        >
-          <PopoverHeader className="mb-4">
-            <PopoverTitle>Search settings</PopoverTitle>
-          </PopoverHeader>
-          <div className="grid gap-4">
-            <Label
-              className="grid gap-1.5 text-xs font-medium tracking-wide text-sidebar-foreground/55"
-              htmlFor="search-placeholder"
-            >
-              Placeholder
-              <Input
-                className="h-9 rounded-[0.85rem] border-sidebar-border/80 bg-background/70 text-sidebar-foreground"
-                id="search-placeholder"
-                onChange={(event) =>
-                  update({ placeholder: event.target.value })
-                }
-                value={value.placeholder}
-              />
-            </Label>
-            <Label
-              className="grid gap-1.5 text-xs font-medium tracking-wide text-sidebar-foreground/55"
-              htmlFor="search-max-results"
-            >
-              Maximum results
-              <Input
-                className="h-9 rounded-[0.85rem] border-sidebar-border/80 bg-background/70 text-sidebar-foreground"
-                id="search-max-results"
-                max={50}
-                min={1}
-                onChange={(event) =>
-                  update({ maxResults: Number(event.target.value) })
-                }
-                type="number"
-                value={value.maxResults}
-              />
-            </Label>
-            <div className="flex items-center justify-between gap-4">
-              <Label className="text-sm" htmlFor="search-file-types">
-                Show file types
-              </Label>
-              <Switch
-                checked={value.showFileType}
-                id="search-file-types"
-                onCheckedChange={(checked) => update({ showFileType: checked })}
-              />
-            </div>
-          </div>
-        </PopoverContent>
-      </Popover>
-    </section>
+    </div>
   );
 }
 
 export const searchEditor = defineOpenEditorCustomBlockEditor({
   block: searchBlock,
-  render: ({ data, updateData }) => (
-    <SearchEditor
-      value={readSearch(data)}
-      onChange={(value) => updateData(value)}
-    />
+  render: ({ data }) => (
+    <section className="not-prose my-4">
+      <SearchPreview value={readSearch(data)} />
+    </section>
   ),
 });
 

--- a/patches/@openeditor%2Freact@0.0.47.patch
+++ b/patches/@openeditor%2Freact@0.0.47.patch
@@ -2,11 +2,12 @@ diff --git a/dist/index.d.ts b/dist/index.d.ts
 index 7eec8927755a5ed9d91e581ef38b0aecd46e8845..efb39192f1fbe050853a93f7757f3ce4ba9d79cf 100644
 --- a/dist/index.d.ts
 +++ b/dist/index.d.ts
-@@ -272,6 +272,7 @@ type OpenEditorReactProps = OpenEditorAuthoringCapabilities & {
+@@ -272,6 +272,8 @@ type OpenEditorReactProps = OpenEditorAuthoringCapabilities & {
          registry: OpenEditorCustomBlockRegistry;
          editors: readonly OpenEditorCustomBlockEditorAdapter[];
          host: OpenEditorCustomBlockEditorHost;
 +        icons?: Readonly<Record<string, OpenEditorSlashMenuIcon>>;
++        blockMenuExtensions?: readonly OpenEditorBlockMenuExtension[];
      };
  };
  type OpenEditorReactConfig = OpenEditorReactProps;
@@ -14,6 +15,14 @@ diff --git a/dist/index.js b/dist/index.js
 index aeefe880b3d38ececcca8a4e251cc6bf39298d93..a8dfc2ccf8e9657a476acf89cc17ecde13db47f1 100644
 --- a/dist/index.js
 +++ b/dist/index.js
+@@ -2618,6 +2618,6 @@ var useOpenEditorController = ({
+     const resolver = createOpenEditorBlockMenuResolver({
+       target: createOpenEditorBlockTarget(() => currentEditorRef.current, ref),
+-      getExtensions: () => []
++      getExtensions: () => customBlocks?.blockMenuExtensions ?? []
+     });
+     blockMenuResolversRef.current.set(key, resolver);
+     return resolver;
 @@ -2696,6 +2696,7 @@ var useOpenEditorController = ({
          key: definition.id,
          label: definition.label,


### PR DESCRIPTION
## What changed

- Restore the editor block-menu Configure action for Directory, Library, and Search.
- Remove the inline gear buttons from Library and Search.
- Keep Decision Tree and Quick Links unchanged.
- Add one focused regression test for the intended menu availability.

## Root cause

The custom-block refactor replaced the extension registration that supplied these menu panels. The block interfaces remained, but their configuration controls moved back into inline popovers.

## Validation

- 222 tests passed
- all package type checks passed
- Biome lint passed
- production build passed