### PR TITLE
Refine website quick links

### DIFF
--- a/apps/web/features/openeditor/custom-block-host.tsx
+++ b/apps/web/features/openeditor/custom-block-host.tsx
@@ -1,13 +1,5 @@
 "use client";
 
-import { AppWindowIcon, Link02Icon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
-
-const iconCatalog = [
-  { id: "link", label: "Link" },
-  { id: "app", label: "App" },
-] as const;
-
 const safeUrl = (value: string, _context: "navigation" | "asset") => {
   const trimmed = value.trim();
   if (!trimmed) return null;
@@ -28,16 +20,9 @@ export const createBaseBlocksCustomBlockHost = (
 ) => ({
   resolveUrl: safeUrl,
   links: {
-    resolve: ({ href: value, kind }: { href: string; kind?: string }) => {
-      const href =
-        kind === "app" &&
-        /^[a-z][a-z\d+.-]*:\/\//i.test(value) &&
-        !/^(?:javascript|data|vbscript):/i.test(value)
-          ? value.trim()
-          : safeUrl(value, "navigation");
-      return href
-        ? { href, external: kind !== "app" && !href.startsWith("/") }
-        : null;
+    resolve: ({ href: value }: { href: string; kind?: string }) => {
+      const href = safeUrl(value, "navigation");
+      return href ? { href, external: !href.startsWith("/") } : null;
     },
   },
   assets: {
@@ -46,11 +31,5 @@ export const createBaseBlocksCustomBlockHost = (
       authorizedAssetIds.has(id) && /^[A-Za-z0-9_-]+$/.test(id)
         ? { src: `/api/files/${encodeURIComponent(id)}`, alt: "" }
         : null,
-  },
-  icons: {
-    list: () => iconCatalog,
-    render: (id: string) => (
-      <HugeiconsIcon icon={id === "app" ? AppWindowIcon : Link02Icon} />
-    ),
   },
 });

--- a/apps/web/features/openeditor/custom-blocks.test.ts
+++ b/apps/web/features/openeditor/custom-blocks.test.ts
@@ -7,15 +7,14 @@ const quickLinksWithAsset = (assetId: string) => ({
   attrs: {
     "openeditor-id": `quick-links-${assetId}`,
     blockId: "baseblocks.quick-links",
-    version: 1,
+    version: 2,
     data: {
       links: [
         {
           id: `link-${assetId}`,
           title: "Documentation",
           url: "https://example.com",
-          linkType: "website",
-          artwork: { kind: "asset", assetId },
+          imageAssetId: assetId,
         },
       ],
     },

--- a/packages/backend/convex/pageContentFormat.test.ts
+++ b/packages/backend/convex/pageContentFormat.test.ts
@@ -257,14 +257,13 @@ describe("extractOpenEditorText", () => {
                         attrs: {
                           "openeditor-id": "links",
                           blockId: "baseblocks.quick-links",
-                          version: 1,
+                          version: 2,
                           data: {
                             links: [
                               {
                                 id: "docs",
                                 title: "Documentation",
                                 url: "/docs",
-                                linkType: "website",
                               },
                             ],
                           },

--- a/packages/backend/convex/published.test.ts
+++ b/packages/backend/convex/published.test.ts
@@ -61,18 +61,14 @@ describe("published page images", () => {
             attrs: {
               "openeditor-id": "quick-links-released",
               blockId: "baseblocks.quick-links",
-              version: 1,
+              version: 2,
               data: {
                 links: [
                   {
                     id: "link-1",
                     title: "Released link",
                     url: "https://example.com",
-                    linkType: "website",
-                    artwork: {
-                      kind: "asset",
-                      assetId: "custom-image-released",
-                    },
+                    imageAssetId: "custom-image-released",
                   },
                 ],
               },

--- a/packages/custom-blocks/src/index.ts
+++ b/packages/custom-blocks/src/index.ts
@@ -98,16 +98,52 @@ export const decisionTreeBlock = defineOpenEditorCustomBlock({
 export const quickLinksBlock = defineOpenEditorCustomBlock({
   id: "baseblocks.quick-links",
   label: "Quick Links",
-  version: 1,
+  version: 2,
   createData: () => ({ links: [] }),
   parseData: parseQuickLinksData,
+  migrate: ({ version, data }) => {
+    const rawLinks = (data as { links?: unknown }).links;
+    if (version !== 1 || !Array.isArray(rawLinks))
+      throw new Error("Unsupported Quick Links version.");
+    const links = rawLinks.flatMap((item: unknown) => {
+      if (
+        !item ||
+        typeof item !== "object" ||
+        Array.isArray(item) ||
+        (item as Record<string, unknown>).linkType !== "website"
+      )
+        return [];
+      const link = item as Record<string, unknown>;
+      const artwork =
+        link.artwork &&
+        typeof link.artwork === "object" &&
+        !Array.isArray(link.artwork)
+          ? (link.artwork as Record<string, unknown>)
+          : null;
+      return [
+        {
+          id: link.id,
+          title: link.title,
+          url: link.url,
+          ...(artwork?.kind === "asset" && typeof artwork.assetId === "string"
+            ? { imageAssetId: artwork.assetId }
+            : {}),
+        },
+      ];
+    });
+    return {
+      blockId: "baseblocks.quick-links",
+      version: 2,
+      data: parseQuickLinksData({ links }),
+    };
+  },
   assets: ({ links }) =>
     links.flatMap((link, index) =>
-      link.artwork?.kind === "asset"
+      link.imageAssetId
         ? [
             {
-              id: link.artwork.assetId,
-              path: `$.data.links[${index}].artwork.assetId`,
+              id: link.imageAssetId,
+              path: `$.data.links[${index}].imageAssetId`,
             },
           ]
         : [],
@@ -117,7 +153,7 @@ export const quickLinksBlock = defineOpenEditorCustomBlock({
       tag: "ul",
       children: data.links.flatMap<OpenEditorCustomBlockSafeHtml>((link) => {
         const href = safeQuickLinkHref(link);
-        return href && link.linkType !== "app"
+        return href
           ? [
               {
                 tag: "li" as const,

--- a/packages/custom-blocks/src/quick-links-editor.tsx
+++ b/packages/custom-blocks/src/quick-links-editor.tsx
@@ -2,10 +2,9 @@
 
 import {
   Add01Icon,
-  AppWindowIcon,
   ArrowUpRight01Icon,
   Delete01Icon,
-  ImageAdd01Icon,
+  Image01Icon,
   Link02Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
@@ -19,13 +18,18 @@ import {
 } from "@baseblocks/ui/dialog";
 import { Input } from "@baseblocks/ui/input";
 import { Label } from "@baseblocks/ui/label";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@baseblocks/ui/tooltip";
 import { defineOpenEditorCustomBlockEditor } from "@openeditor/custom-block/editor";
 import type { OpenEditorCustomBlockEditorHost } from "@openeditor/custom-block/editor";
-import { type ReactNode, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { quickLinksBlock } from "./index";
 import { QuickLinkAssetLoader } from "./quick-link-asset-loader";
 import { destinationLabel, type QuickLink } from "./quick-links";
-import { BlockShell, selectClassName } from "./ui";
+import { BlockShell } from "./ui";
 
 const createId = () => crypto.randomUUID();
 type LinkDraft = Omit<QuickLink, "id"> & { id: string | null };
@@ -34,7 +38,6 @@ const emptyDraft = (): LinkDraft => ({
   id: null,
   title: "",
   url: "",
-  linkType: "website",
 });
 
 export const quickLinksEditor = defineOpenEditorCustomBlockEditor({
@@ -43,7 +46,7 @@ export const quickLinksEditor = defineOpenEditorCustomBlockEditor({
     const updateDataJson = (value: unknown) => updateData(value as typeof data);
     const [draft, setDraft] = useState<LinkDraft | null>(null);
     const resolved = draft
-      ? host.links?.resolve({ href: draft.url, kind: draft.linkType })
+      ? host.links?.resolve({ href: draft.url, kind: "website" })
       : null;
 
     return (
@@ -66,15 +69,11 @@ export const quickLinksEditor = defineOpenEditorCustomBlockEditor({
               type="button"
             >
               <span className="flex size-11 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-primary/10 text-primary">
-                {link.artwork?.kind === "icon" && host.icons ? (
-                  (host.icons.render(link.artwork.id) as ReactNode)
-                ) : link.artwork?.kind === "asset" ? (
+                {link.imageAssetId ? (
                   <QuickLinkEditorAsset
-                    assetId={link.artwork.assetId}
+                    assetId={link.imageAssetId}
                     host={host}
                   />
-                ) : link.linkType === "app" ? (
-                  <HugeiconsIcon aria-hidden icon={AppWindowIcon} />
                 ) : (
                   <HugeiconsIcon aria-hidden icon={Link02Icon} />
                 )}
@@ -103,13 +102,33 @@ export const quickLinksEditor = defineOpenEditorCustomBlockEditor({
           open={draft !== null}
         >
           {draft ? (
-            <DialogContent className="w-[calc(100%-2rem)] max-w-[32rem] overflow-hidden rounded-[1.5rem] border-sidebar-border bg-sidebar p-0 text-sidebar-foreground shadow-2xl sm:max-w-[32rem]">
-              <DialogHeader>
-                <DialogTitle className="px-5 pt-4 text-base">
+            <DialogContent className="w-[calc(100%-1.5rem)] max-w-[26rem] gap-0 overflow-hidden rounded-2xl border-0 bg-background/80 p-0 text-foreground shadow-2xl backdrop-blur-xl backdrop-saturate-150 sm:max-w-[26rem] [&_[data-slot='dialog-close']]:top-2 [&_[data-slot='dialog-close']]:right-2 [&_[data-slot='dialog-close']]:flex [&_[data-slot='dialog-close']]:size-8 [&_[data-slot='dialog-close']]:items-center [&_[data-slot='dialog-close']]:justify-center [&_[data-slot='dialog-close']]:rounded-lg">
+              <DialogHeader className="px-4 pt-4 pe-12">
+                <DialogTitle className="brand-display text-2xl leading-none font-normal tracking-[-0.025em]">
                   {draft.id ? "Edit quick link" : "Add quick link"}
                 </DialogTitle>
               </DialogHeader>
-              <div className="grid gap-4 px-5">
+              <form
+                className="grid gap-4 px-4 pt-4 pb-4"
+                onSubmit={(event) => {
+                  event.preventDefault();
+                  if (!resolved || !draft.title.trim()) return;
+                  const value: QuickLink = {
+                    id: draft.id ?? createId(),
+                    title: draft.title.trim(),
+                    url: draft.url.trim(),
+                    imageAssetId: draft.imageAssetId,
+                  };
+                  updateDataJson({
+                    links: draft.id
+                      ? data.links.map((link) =>
+                          link.id === draft.id ? value : link,
+                        )
+                      : [...data.links, value],
+                  });
+                  setDraft(null);
+                }}
+              >
                 <div className="grid gap-1.5">
                   <Label htmlFor="quick-link-title">Title</Label>
                   <Input
@@ -122,143 +141,112 @@ export const quickLinksEditor = defineOpenEditorCustomBlockEditor({
                   />
                 </div>
                 <div className="grid gap-1.5">
-                  <Label htmlFor="quick-link-destination">Destination</Label>
+                  <Label htmlFor="quick-link-destination">Website URL</Label>
                   <Input
                     aria-invalid={Boolean(draft.url && !resolved)}
                     id="quick-link-destination"
                     onChange={(event) =>
                       setDraft({ ...draft, url: event.target.value })
                     }
-                    placeholder={
-                      draft.linkType === "app"
-                        ? "myapp://open"
-                        : "https://example.com"
-                    }
+                    placeholder="https://example.com"
                     value={draft.url}
                   />
                   {draft.url && !resolved ? (
                     <p className="text-xs text-destructive">
-                      Enter a valid destination.
+                      Enter an HTTP, HTTPS, or site-relative URL.
                     </p>
                   ) : null}
                 </div>
-                <div className="grid grid-cols-2 gap-3">
-                  <div className="grid gap-1.5">
-                    <Label htmlFor="quick-link-type">Link type</Label>
-                    <select
-                      className={`${selectClassName} w-full`}
-                      id="quick-link-type"
-                      onChange={(event) =>
-                        setDraft({
-                          ...draft,
-                          linkType:
-                            event.target.value === "app" ? "app" : "website",
-                        })
-                      }
-                      value={draft.linkType}
-                    >
-                      <option value="website">Website</option>
-                      <option value="app">App</option>
-                    </select>
-                  </div>
-                  {host.icons ? (
-                    <div className="grid gap-1.5">
-                      <Label htmlFor="quick-link-icon">Icon</Label>
-                      <select
-                        className={`${selectClassName} w-full`}
-                        id="quick-link-icon"
-                        onChange={(event) =>
-                          setDraft({
-                            ...draft,
-                            artwork: event.target.value
-                              ? { kind: "icon", id: event.target.value }
-                              : undefined,
-                          })
-                        }
-                        value={
-                          draft.artwork?.kind === "icon" ? draft.artwork.id : ""
-                        }
-                      >
-                        <option value="">No icon</option>
-                        {host.icons.list().map((icon) => (
-                          <option key={icon.id} value={icon.id}>
-                            {icon.label}
-                          </option>
-                        ))}
-                      </select>
-                    </div>
-                  ) : null}
-                </div>
                 {host.assets?.pick ? (
-                  <Button
-                    className="w-fit"
-                    onClick={async () => {
-                      const asset = await host.assets?.pick?.();
-                      if (asset)
-                        setDraft({
-                          ...draft,
-                          artwork: { kind: "asset", assetId: asset.id },
+                  <div className="flex items-center justify-between gap-4">
+                    <p className="text-sm font-medium">Image</p>
+                    <div className="group relative shrink-0">
+                      <button
+                        aria-label={
+                          draft.imageAssetId
+                            ? "Replace quick link image"
+                            : "Choose quick link image"
+                        }
+                        className="group flex h-20 w-28 items-center justify-center overflow-hidden rounded-lg border-2 border-dashed border-muted-foreground/25 bg-background text-muted-foreground transition-[border-color,background-color] hover:border-muted-foreground/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+                        onClick={async () => {
+                          const asset = await host.assets?.pick?.();
+                          if (asset)
+                            setDraft({ ...draft, imageAssetId: asset.id });
+                        }}
+                        type="button"
+                      >
+                        {draft.imageAssetId ? (
+                          <>
+                            <QuickLinkEditorAsset
+                              assetId={draft.imageAssetId}
+                              host={host}
+                            />
+                            <span className="absolute inset-x-0 bottom-0 bg-background/90 py-1 text-center text-[11px] text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100">
+                              Replace
+                            </span>
+                          </>
+                        ) : (
+                          <HugeiconsIcon
+                            aria-hidden
+                            className="size-5"
+                            icon={Image01Icon}
+                          />
+                        )}
+                      </button>
+                      {draft.imageAssetId ? (
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button
+                              aria-label="Remove quick link image"
+                              className="absolute top-1 end-1 size-7 bg-background/90 text-muted-foreground opacity-100 shadow-sm transition-opacity hover:text-destructive sm:opacity-0 sm:group-hover:opacity-100"
+                              onClick={() =>
+                                setDraft({
+                                  ...draft,
+                                  imageAssetId: undefined,
+                                })
+                              }
+                              size="icon-xs"
+                              type="button"
+                              variant="ghost"
+                            >
+                              <HugeiconsIcon aria-hidden icon={Delete01Icon} />
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent sideOffset={6}>Remove</TooltipContent>
+                        </Tooltip>
+                      ) : null}
+                    </div>
+                  </div>
+                ) : null}
+                <DialogFooter
+                  className={
+                    draft.id ? "pt-1 sm:justify-between" : "pt-1 sm:justify-end"
+                  }
+                >
+                  {draft.id ? (
+                    <Button
+                      className="mr-auto text-destructive hover:text-destructive"
+                      onClick={() => {
+                        updateDataJson({
+                          links: data.links.filter(({ id }) => id !== draft.id),
                         });
-                    }}
-                    type="button"
-                    variant="outline"
-                  >
-                    <HugeiconsIcon aria-hidden icon={ImageAdd01Icon} />
-                    {draft.artwork?.kind === "asset"
-                      ? "Change image"
-                      : "Choose image"}
-                  </Button>
-                ) : null}
-              </div>
-              <DialogFooter className="px-5 pb-4 sm:justify-between">
-                {draft.id ? (
+                        setDraft(null);
+                      }}
+                      type="button"
+                      variant="ghost"
+                    >
+                      <HugeiconsIcon aria-hidden icon={Delete01Icon} />
+                      Delete
+                    </Button>
+                  ) : null}
                   <Button
-                    className="mr-auto text-destructive hover:text-destructive"
-                    onClick={() => {
-                      updateDataJson({
-                        links: data.links.filter(({ id }) => id !== draft.id),
-                      });
-                      setDraft(null);
-                    }}
-                    type="button"
-                    variant="ghost"
+                    disabled={!draft.title.trim() || !resolved}
+                    type="submit"
                   >
-                    <HugeiconsIcon aria-hidden icon={Delete01Icon} />
-                    Delete
+                    Save
                   </Button>
-                ) : null}
-                <Button
-                  onClick={() => setDraft(null)}
-                  type="button"
-                  variant="outline"
-                >
-                  Cancel
-                </Button>
-                <Button
-                  disabled={!draft.title.trim() || !resolved}
-                  onClick={() => {
-                    if (!resolved) return;
-                    const value: QuickLink = {
-                      id: draft.id ?? createId(),
-                      title: draft.title.trim(),
-                      url: draft.url,
-                      linkType: draft.linkType,
-                      artwork: draft.artwork,
-                    };
-                    updateDataJson({
-                      links: draft.id
-                        ? data.links.map((link) =>
-                            link.id === draft.id ? value : link,
-                          )
-                        : [...data.links, value],
-                    });
-                    setDraft(null);
-                  }}
-                  type="button"
-                >
-                  Save
-                </Button>
-              </DialogFooter>
+                </DialogFooter>
+              </form>
             </DialogContent>
           ) : null}
         </Dialog>
@@ -283,6 +271,6 @@ function QuickLinkEditorAsset({
   return asset ? (
     <img alt={asset.alt} className="size-full object-cover" src={asset.src} />
   ) : (
-    <HugeiconsIcon aria-hidden icon={ImageAdd01Icon} />
+    <HugeiconsIcon aria-hidden icon={Image01Icon} />
   );
 }

--- a/packages/custom-blocks/src/quick-links.test.ts
+++ b/packages/custom-blocks/src/quick-links.test.ts
@@ -6,15 +6,61 @@ import {
   updateQuickLink,
   safeQuickLinkHref,
 } from "./quick-links";
+import { quickLinksBlock } from "./index";
 
 describe("quick links data", () => {
+  test("migrates website links and removes unsupported app links and icons", () => {
+    expect(
+      quickLinksBlock.migrate?.({
+        version: 1,
+        data: {
+          links: [
+            {
+              id: "website",
+              title: "Website",
+              url: "https://example.com",
+              linkType: "website",
+              artwork: { kind: "asset", assetId: "website-image" },
+            },
+            {
+              id: "icon",
+              title: "Icon",
+              url: "/icon",
+              linkType: "website",
+              artwork: { kind: "icon", id: "book" },
+            },
+            {
+              id: "app",
+              title: "App",
+              url: "baseblocks://open",
+              linkType: "app",
+            },
+          ],
+        },
+      }),
+    ).toEqual({
+      blockId: "baseblocks.quick-links",
+      version: 2,
+      data: {
+        links: [
+          {
+            id: "website",
+            title: "Website",
+            url: "https://example.com",
+            imageAssetId: "website-image",
+          },
+          { id: "icon", title: "Icon", url: "/icon" },
+        ],
+      },
+    });
+  });
+
   test("accepts site-relative and HTTP links but rejects executable URLs", () => {
     expect(
       safeQuickLinkHref({
         id: "1",
         title: "Page",
         url: "/about",
-        linkType: "website",
       }),
     ).toBe("/about");
     expect(
@@ -22,7 +68,6 @@ describe("quick links data", () => {
         id: "2",
         title: "Web",
         url: "https://example.com",
-        linkType: "website",
       }),
     ).toBe("https://example.com");
     expect(
@@ -30,7 +75,6 @@ describe("quick links data", () => {
         id: "query",
         title: "Query",
         url: "https://example.com/search?a=1&b=2",
-        linkType: "website",
       }),
     ).toBe("https://example.com/search?a=1&b=2");
     expect(
@@ -38,7 +82,6 @@ describe("quick links data", () => {
         id: "3",
         title: "Bad",
         url: "javascript:alert(1)",
-        linkType: "website",
       }),
     ).toBeNull();
     expect(
@@ -46,15 +89,13 @@ describe("quick links data", () => {
         id: "encoded",
         title: "Encoded",
         url: "jav&#x61;script:alert(1)",
-        linkType: "website",
       }),
     ).toBeNull();
     expect(
       safeQuickLinkHref({
-        id: "4",
-        title: "Bad app",
+        id: "scheme",
+        title: "App scheme",
         url: "data://payload",
-        linkType: "app",
       }),
     ).toBeNull();
   });
@@ -65,7 +106,6 @@ describe("quick links data", () => {
         id: "1",
         title: "Page",
         url: "/about",
-        linkType: "website",
       }),
     ).toBe("BaseBlocks page");
     expect(
@@ -73,28 +113,27 @@ describe("quick links data", () => {
         id: "2",
         title: "Docs",
         url: "https://www.example.com/docs",
-        linkType: "website",
       }),
     ).toBe("example.com");
-    const app = {
-      id: "app",
-      title: "Open app",
-      url: "baseblocks://open",
-      linkType: "app" as const,
+    const website = {
+      id: "docs",
+      title: "Open docs",
+      url: "https://example.com/docs",
     };
-    expect(updateQuickLink([app], { ...app, title: "Launch app" })[0]).toEqual({
-      ...app,
-      title: "Launch app",
+    expect(
+      updateQuickLink([website], { ...website, title: "Read docs" })[0],
+    ).toEqual({
+      ...website,
+      title: "Read docs",
     });
   });
 
-  test("duplicates and reorders links with portable artwork references", () => {
+  test("duplicates and reorders links with portable image references", () => {
     const original = {
       id: "one",
       title: "Docs",
       url: "/docs",
-      linkType: "website" as const,
-      artwork: { kind: "icon" as const, id: "book" },
+      imageAssetId: "docs-image",
     };
     expect(duplicateQuickLink(original, "copy")).toEqual({
       ...original,

--- a/packages/custom-blocks/src/quick-links.ts
+++ b/packages/custom-blocks/src/quick-links.ts
@@ -2,8 +2,7 @@ export type QuickLink = {
   id: string;
   title: string;
   url: string;
-  artwork?: { kind: "icon"; id: string } | { kind: "asset"; assetId: string };
-  linkType: "website" | "app";
+  imageAssetId?: string;
 };
 
 export type QuickLinksData = { links: QuickLink[] };
@@ -27,33 +26,19 @@ export function parseQuickLinksData(value: unknown): QuickLinksData {
       throw new Error("Each Quick Link needs a title.");
     if (typeof link.url !== "string")
       throw new Error("Each Quick Link needs a destination.");
-    if (link.linkType !== "website" && link.linkType !== "app")
-      throw new Error("Quick Link type is invalid.");
-    let artwork: QuickLink["artwork"];
-    if (link.artwork !== undefined) {
-      if (
-        !link.artwork ||
-        typeof link.artwork !== "object" ||
-        Array.isArray(link.artwork)
-      )
-        throw new Error("Quick Link artwork is invalid.");
-      const rawArtwork = link.artwork as Record<string, unknown>;
-      if (rawArtwork.kind === "icon" && typeof rawArtwork.id === "string")
-        artwork = { kind: "icon", id: rawArtwork.id };
-      else if (
-        rawArtwork.kind === "asset" &&
-        typeof rawArtwork.assetId === "string" &&
-        /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/.test(rawArtwork.assetId)
-      )
-        artwork = { kind: "asset", assetId: rawArtwork.assetId };
-      else throw new Error("Quick Link artwork is invalid.");
-    }
+    if (
+      link.imageAssetId !== undefined &&
+      (typeof link.imageAssetId !== "string" ||
+        !/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/.test(link.imageAssetId))
+    )
+      throw new Error("Quick Link image is invalid.");
     const parsed: QuickLink = {
       id: link.id,
       title: link.title,
       url: link.url,
-      linkType: link.linkType,
-      ...(artwork ? { artwork } : {}),
+      ...(typeof link.imageAssetId === "string"
+        ? { imageAssetId: link.imageAssetId }
+        : {}),
     };
     if (!safeQuickLinkHref(parsed))
       throw new Error("Quick Links contains an unsafe destination.");
@@ -67,7 +52,6 @@ export function duplicateQuickLink(link: QuickLink, id: string): QuickLink {
     ...link,
     id,
     title: `${link.title} copy`,
-    artwork: link.artwork ? { ...link.artwork } : undefined,
   };
 }
 
@@ -95,12 +79,6 @@ export function updateQuickLink(
 export function safeQuickLinkHref(link: QuickLink): string | null {
   const url = link.url.trim();
   if (!url) return null;
-  if (link.linkType === "app") {
-    return /^[a-z][a-z\d+.-]*:\/\//i.test(url) &&
-      !/^(?:javascript|data|vbscript):/i.test(url)
-      ? url
-      : null;
-  }
   if (url.startsWith("/") && !url.startsWith("//")) return url;
   try {
     const parsed = new URL(url);
@@ -113,7 +91,6 @@ export function safeQuickLinkHref(link: QuickLink): string | null {
 }
 
 export function destinationLabel(link: QuickLink): string {
-  if (link.linkType === "app") return "Open app";
   if (link.url.startsWith("/")) return "BaseBlocks page";
   try {
     return new URL(link.url).hostname.replace(/^www\./, "");

--- a/packages/custom-blocks/src/viewer.tsx
+++ b/packages/custom-blocks/src/viewer.tsx
@@ -5,7 +5,6 @@
 import { defineOpenEditorCustomBlockViewer } from "@openeditor/custom-block/viewer";
 import { getDocumentText } from "@openeditor/core";
 import {
-  AppWindowIcon,
   ArrowLeft01Icon,
   ArrowRight01Icon,
   ArrowUpRight01Icon,
@@ -15,7 +14,7 @@ import {
 import { HugeiconsIcon } from "@hugeicons/react";
 import { Button } from "@baseblocks/ui/button";
 import { Input } from "@baseblocks/ui/input";
-import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { OpenEditorCustomBlockViewerHost } from "@openeditor/custom-block/viewer";
 import type { QuickLink } from "./quick-links";
 import { decisionTreeBlock, directoryBlock, quickLinksBlock } from "./index";
@@ -242,7 +241,7 @@ export const quickLinksViewer = defineOpenEditorCustomBlockViewer({
           {data.links.map((link) => {
             const resolved = host.links?.resolve({
               href: link.url,
-              kind: link.linkType,
+              kind: "website",
             });
             if (!resolved) return null;
             return (
@@ -286,20 +285,11 @@ function QuickLinkArtwork({
 }) {
   const [asset, setAsset] = useState<{ src: string; alt: string } | null>(null);
   const loader = useRef(new QuickLinkAssetLoader());
-  const assetId = link.artwork?.kind === "asset" ? link.artwork.assetId : null;
+  const assetId = link.imageAssetId ?? null;
   useEffect(() => {
     loader.current.load(assetId, host, setAsset);
     return () => loader.current.cancel();
   }, [assetId, host]);
-  if (link.artwork?.kind === "icon")
-    return (
-      <span
-        aria-hidden
-        className="flex size-11 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-primary/10 text-primary"
-      >
-        {host.icons?.render(link.artwork.id) as ReactNode}
-      </span>
-    );
   return (
     <span className="flex size-11 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-primary/10 text-primary">
       {asset ? (
@@ -308,8 +298,6 @@ function QuickLinkArtwork({
           className="size-full object-cover"
           src={asset.src}
         />
-      ) : link.linkType === "app" ? (
-        <HugeiconsIcon aria-hidden className="size-5" icon={AppWindowIcon} />
       ) : (
         <HugeiconsIcon aria-hidden className="size-5" icon={Link02Icon} />
       )}

--- a/packages/domain/src/content/elements/index.ts
+++ b/packages/domain/src/content/elements/index.ts
@@ -4,7 +4,6 @@ export type {
   DirectoryContent,
   SearchContent,
   LibraryContent,
-  QuicklinkType,
   QuicklinkItem,
   SaveStatus,
 } from "./schema";

--- a/packages/domain/src/content/elements/schema.ts
+++ b/packages/domain/src/content/elements/schema.ts
@@ -26,14 +26,11 @@ export interface LibraryContent {
   allowDownloads?: boolean;
 }
 
-export type QuicklinkType = "website" | "app";
-
 export interface QuicklinkItem {
   id: string;
   title: string;
   url: string;
   imageUrl?: string;
-  linkType?: QuicklinkType;
 }
 
 export type SaveStatus = "idle" | "pending" | "saving" | "saved" | "error";

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -52,7 +52,6 @@ export type {
   DirectoryContent,
   SearchContent,
   LibraryContent,
-  QuicklinkType,
   QuicklinkItem,
 } from "./content/elements";
 


### PR DESCRIPTION
## Summary

- refactor quick links to support websites only
- remove app-link types and configurable icons from the data model and host
- align the quick-link dialog with the site-settings layout and asset control
- add a versioned migration that removes app links and converts image assets

## Validation

- `bun --cwd packages/custom-blocks test`
- `bun --cwd packages/custom-blocks check-types`
- `bun --cwd packages/custom-blocks lint`
- `bun --cwd packages/domain check-types`
- `bun --cwd apps/web check-types`
- `bun --cwd apps/web lint`
- `bun --cwd packages/backend check-types`
- focused web and backend tests